### PR TITLE
Fixes issue with short timestamp generation

### DIFF
--- a/src/helpers/__test__/converters.test.ts
+++ b/src/helpers/__test__/converters.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, should, vi } from "vitest";
 import { convertToLongTimestamp, convertToShortTimestamp } from "../converters";
 
 describe('attempt convert timestamp into long readable date', () => {
@@ -20,33 +20,104 @@ describe('attempt convert timestamp into long readable date', () => {
 })
 
 describe('attempt to convert into short readable date', () => {
-    var curDayInSameHour = new Date();
-    var curDayPastHoursNonExact = new Date();
-    var curDayPastHoursExact = new Date();
-    var subtractInHour = 45;
-    var subtractInDay = 100;
-    var subtractExactHours = 3;
-
-    curDayInSameHour.setMinutes(curDayInSameHour.getMinutes()-subtractInHour);
-    curDayPastHoursNonExact.setMinutes(curDayPastHoursNonExact.getMinutes()-subtractInDay);
-    curDayPastHoursExact.setHours(curDayPastHoursExact.getHours()-subtractExactHours);
+    beforeAll(() => {
+        vi.useFakeTimers();
+    })
+    afterAll(() => {
+        vi.useRealTimers();
+    })
 
     it('should fail when given invalid date format', () => {
         expect(convertToShortTimestamp('this is not a valid date')).toBe('invalid');
     })
-    it('should return valid short timestamp - format for past day, same year', () => {
-        expect(convertToShortTimestamp('2025-01-16T13:37:00')).toBe('Jan 16');
+    it('should return valid short timestamp - posted under 1 minute ago', () => {
+        const fakeDate = new Date(2025,5,27,16,5);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-27T16:04:30')).toBe('30sec');
     })
-    it('should return valid short timestamp - format for past year', () => {
-        expect(convertToShortTimestamp('2024-01-23T13:37:00')).toBe('Jan 23 2024');
+    it('should return valid short timestamp - posted under 1 minute in the future', () => {
+        const fakeDate = new Date(2025,5,27,16,5);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-27T16:05:30')).toBe('-30sec');
     })
-    it('should return valid short timestamp - format for same day, last hour', () => {
-        expect(convertToShortTimestamp(curDayInSameHour.toUTCString())).toBe(subtractInHour+'m');
+    it('should return valid short timestamp - posted under 1 hour ago', () => {
+        const fakeDate = new Date(2025,5,27,16,5);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-27T15:23:00')).toBe('42m');
     })
-    it('should return valid short timestamp - format for same day, over an hour ago non exact', () => {
-        expect(convertToShortTimestamp(curDayPastHoursNonExact.toUTCString())).toBe(Math.floor(subtractInDay/60)+'h');
+    it('should return valid short timestamp - posted under 1 hour in the future', () => {
+        const fakeDate = new Date(2025,5,27,16,5);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-27T16:23:00')).toBe('-18m');
     })
-    it('should return valid short timestamp - format for same day, over an hour ago exact', () => {
-        expect(convertToShortTimestamp(curDayPastHoursExact.toUTCString())).toBe('3h');
+    it('should return valid short timestamp - posted under 24 hours ago, same day, hour rounded up', () => {
+        const fakeDate = new Date(2025,5,27,16);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-27T02:22:00')).toBe('14h');
+    })
+    it('should return valid short timestamp - posted under 24 hours ago, same day, hour rounded down', () => {
+        const fakeDate = new Date(2025,5,27,16);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-27T02:42:00')).toBe('13h');
+    })
+    it('should return valid short timestamp - posted under 24 hours ago, prev day, hour rounded up', () => {
+        const fakeDate = new Date(2025,5,27,2,42);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-26T20:00:00')).toBe('7h');
+    })
+    it('should return valid short timestamp - posted under 24 hours ago, prev day, hour rounded down', () => {
+        const fakeDate = new Date(2025,5,27,0,49);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-26T23:25:00')).toBe('1h');
+    })
+    it('should return valid short timestamp - posted in 24 hours range +/-, future/next day, hour rounded up', () => {
+        const fakeDate = new Date(2025,5,26,20);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-27T02:42:00')).toBe('-7h');
+    })
+    it('should return valid short timestamp - posted under 24 hours ago, prev day + prev year, hour rounded up', () => {
+        const fakeDate = new Date(2025,0,1,4,42);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2024-12-31T20:52:00')).toBe('8h');
+    })
+    it('should return valid short timestamp - posted under 24 hours ago, prev day + prev year, hour rounded down', () => {
+        const fakeDate = new Date(2025,0,1,4,52);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2024-12-31T19:32:00')).toBe('9h');
+    })
+    it('should return valid short timestamp - posted in 24 hours range +/-, future day + future year, hour rounded up', () => {
+        const fakeDate = new Date(2024,11,31,22,12);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-01-01T08:44:00')).toBe('-11h');
+    })
+    it('should return valid short timestamp - posted over 24 hours ago, same month + same year', () => {
+        const fakeDate = new Date(2025,5,27,17,7);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-06-24T08:44:00')).toBe('Jun 24');
+    })
+    it('should return valid short timestamp - posted over 24 hours ago, ealier month + same year', () => {
+        const fakeDate = new Date(2025,5,27,17,7);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-05-24T08:44:00')).toBe('May 24');
+    })
+    it('should return valid short timestamp - posted over 24 hours in the future, future month + same year', () => {
+        const fakeDate = new Date(2025,5,27,17,7);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2025-11-11T09:30:00')).toBe('(Future) Nov 11');
+    })
+    it('should return valid short timestamp - posted over 24 hours ago, earlier month + prev year', () => {
+        const fakeDate = new Date(2025,5,27,17,7);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2024-06-24T08:44:00')).toBe('Jun 24 2024');
+    })
+    it('should return valid short timestamp - posted over 24 hours ago, earlier month + earlier year', () => {
+        const fakeDate = new Date(2025,5,27,17,7);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2021-06-24T08:44:00')).toBe('Jun 24 2021');
+    })
+    it('should return valid short timestamp - posted over 24 hours in the future, future month + future year', () => {
+        const fakeDate = new Date(2025,5,27,17,7);
+        vi.setSystemTime(fakeDate);
+        expect(convertToShortTimestamp('2027-06-24T08:44:00')).toBe('Jun 24 2027');
     })
 })

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -6,33 +6,34 @@ export function convertToShortTimestamp(ts:string = ""){
 
         var curDate = new Date();
 
+        var timeDiff = curDate.getTime() - date.getTime();
         var day = date.getDate();
         var year = date.getFullYear();
-        var month = date.getMonth()+1;
-        var hour = date.getUTCHours();
-        var minute = date.getUTCMinutes();
+        var dateFormat = "error - unset";
 
-        var isSameHour = (curDate.getTime() - date.getTime())<(1000*60*60);
-        var isSameDay = curDate.getUTCDate() == date.getUTCDate();
-        var isSameMonth = curDate.getMonth() == date.getMonth();
-        var isSameYear = curDate.getFullYear() == date.getFullYear();
-
-        var dateFormat = "";
-        if(isSameHour){
-            var diff = (curDate.getUTCMinutes() - date.getUTCMinutes());
-            dateFormat = (diff<0?diff+60:diff)+'m'; //if diff is negative, add 60(mins) to get real minutes
+        if(Math.abs(timeDiff) < 1000*60){
+            //under 1 min
+            dateFormat = timeDiff/1000+'sec';
         }
-        else if(isSameDay && isSameMonth){
-            var diff = (curDate.getTime() - date.getTime())
-            //Avoids situations where 13:19-11:59 would return 2h
-            //Maybe we eventually choose to round up...
-            dateFormat = Math.floor(diff/(1000*60*60))+'h';
+        else if(Math.abs(timeDiff) < 1000*60*60){
+            //under 1 hour
+            dateFormat = timeDiff/(1000*60)+'m';
         }
-        else if(isSameYear){
-            dateFormat = getMonthNameShort(date, 'en-US')+" "+day;
+        else if(Math.abs(timeDiff) < 1000*60*60*24){
+            //under 24 hours
+            dateFormat = Math.round(timeDiff/(1000*60*60))+'h';
+        }
+        else if(year != curDate.getFullYear()){
+            //different year
+            dateFormat = getMonthNameShort(date, 'en-US')+" "+day+" "+year;
+        }
+        else if(timeDiff<0){
+            //future date over 24 hours in future in same year
+            dateFormat = "(Future) "+getMonthNameShort(date, 'en-US')+" "+day;
         }
         else{
-            dateFormat = getMonthNameShort(date, 'en-US')+" "+day+" "+year;
+            //any other situation, same year
+            dateFormat = getMonthNameShort(date, 'en-US')+" "+day;
         }
 
         return dateFormat;


### PR DESCRIPTION
- Updated `converters.convertToShortTimestamp()` so that it correctly generates "short timestamps" that follow the criteria outlined in #131.