### PR TITLE
Updates build process to remove debug log messages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig(async ({mode}) => {
       globals: true,
       environment: "jsdom",
     },
+    //Hide DEBUG messages outside of dev environment
+    esbuild:{
+      pure: ['console.log'],
+    },
 
     // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
     //


### PR DESCRIPTION
- Made changes to the build process so that `console.log()` calls used to print debug messages will not be displayed outside of devlopment environments.