### PR TITLE
#146 - Update `PostFocusModal` image display to allow downloads

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -94,6 +94,7 @@ declare module 'vue' {
     SaveMediaModal: typeof import('./src/components/Utilities/SaveMediaModal.vue')['default']
     SettingsCategory: typeof import('./src/components/Settings/SettingsCategory.vue')['default']
     SettingsPanel: typeof import('./src/components/Settings/SettingsPanel.vue')['default']
+    SlideshowArrow: typeof import('./src/components/Utilities/SlideshowArrow.vue')['default']
     SpoilerOverlay: typeof import('./src/components/Utilities/SpoilerOverlay.vue')['default']
     SquareButton: typeof import('./src/components/Utilities/SquareButton.vue')['default']
     ToContainerTop: typeof import('./src/components/Utilities/ToContainerTop.vue')['default']

--- a/src/components/Feed/FocusFeedPost.vue
+++ b/src/components/Feed/FocusFeedPost.vue
@@ -118,7 +118,7 @@
                     <VideoContainer v-if="postContainsVideo" :video-view="getPostVideo"
                     :labels="postToShow.labels" :author="postToShow.author.handle"/>
                     <div v-if="postContainsExternalEmbed">
-                        <EmbedExternal :embed="getPostEmbed"/>
+                        <EmbedExternal :embed="getPostEmbed" @media-click="(i:number) => isReplyStyle ? emitThreadReplyClicked(threadData ? threadData.post.uri : '', i) : openFocusDetails(i)"/>
                     </div>
                     {{ void "Reposts - ViewRecord and View" }}
                     <FocusFeedPost v-if="postToShow.embed?.record && postToShow.embed?.record.record && AppBskyEmbedRecord.isViewRecord(postToShow.embed.record.record)"

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -1,6 +1,11 @@
 <template>
     <div data-test="post-focus-modal" id="post-focus-modal" tabindex="0"
     class="absolute z-20 h-full w-full flex flex-col sm:flex-row bg-slate-900/90 outline-none overflow-y-auto">
+        {{ void "Fullscreen Image" }}
+        <div v-if="isImageFullscreen" @click="hideImageFullscreen" class="absolute flex h-full w-full text-primary items-center justify-center scroll-auto bg-pink-500 bg-contain bg-center bg-no-repeat z-20"
+        :style="{'background-image': 'url('+(fullscreenImageURL)+'s)'}">
+            <img :src="fullscreenImageURL" class="max-h-full max-w-full"/>
+        </div>
         {{ void "Media Section" }}
         <div class="relative flex flex-col w-full sm:w-3/5 grow min-h-[30rem]">
             <div class="h-10 w-full shrink-0 bg-blacks">
@@ -11,7 +16,7 @@
                 </div>
             </div>
             {{ void "Media Container" }}
-            <div class="flex items-center h-full justify-center overflow-hidden">
+            <div class="flex items-center h-full w-full justify-center overflow-hidden">
                 <div class="flex h-full w-10 shrink-0 items-center mr-auto">
                     <SlideshowArrow v-if="canDecreaseMediaIndex && !postDetails.isAwaitingFocusData" arrow-direction="Left" @button-clicked="decreaseCurrentMediaIndex"/>
                 </div>
@@ -20,7 +25,8 @@
                 class="rounded-sm h-full w-full bg-center bg-contain bg-no-repeat"
                 :style="{'background-image' : 'url('+(getEmbededImageViewImageObjects[currentMediaIndex] as ViewImage).fullsize+')'}">
                 </div> -->
-                <ImageContainer v-else-if="hasImageMedia && !postDetails.isAwaitingFocusData" :show-fullsize="true"
+                <ImageContainer v-else-if="hasImageMedia && !postDetails.isAwaitingFocusData"
+                @image-clicked="showImageFullscreen" :show-fullsize="true"
                 :images-to-display="[getEmbededImageViewImageObjects[currentMediaIndex]]" :author="postThread.post.author.handle"/>
                 <video-container v-else-if="isVideoView(postDetails.currentThreadView.post.embed) && !postDetails.isAwaitingFocusData"
                 class="relative flex flex-col max-w-full h-full justify-center p-5"
@@ -247,6 +253,10 @@ export default defineComponent({
             /**Used to cause the Replies displayed in `PostThreadView` to update when the context changes. */
             isChangingThreadContext:false,
             currentBreadcrumb : [{userName:"Origin",postCID:"this_cid_is_unset"}],
+            /**Is a Post image currently being shown at fullscreen size? */
+            isImageFullscreen: false,
+            /**URL of image to display at fullscreen size. */
+            fullscreenImageURL : ''
         }
     },
     methods:{
@@ -259,6 +269,14 @@ export default defineComponent({
             if(this.currentMediaIndex-1 >= 0)
                 // postDetails.setClickedMediaIndex(postDetails.getClickedMediaIndex()-1);
                 this.currentMediaIndex = this.currentMediaIndex-1;
+        },
+        showImageFullscreen(imageUrl:string){
+            this.fullscreenImageURL = imageUrl;
+            this.isImageFullscreen = true;
+        },
+        hideImageFullscreen(){
+            this.isImageFullscreen = false;
+            this.fullscreenImageURL = '';
         },
         hideModal(){
             postDetails.hideFocusModal();

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -5,7 +5,7 @@
         <Transition>
             <div v-if="isImageFullscreen" @click="hideImageFullscreen" class="fixed flex h-full w-full text-primary items-center justify-center scroll-auto bg-black/95 bg-contain bg-center bg-no-repeat z-20"
             :style="{'background-image': 'url('+(fullscreenImage)+'s)'}">
-                <div @click="(e)=>{e.stopPropagation()}" class="absolute text-black bottom-0 left-0 px-2 bg-white/50 z-10">
+                <div v-if="!(fullscreenImage as ViewExternal).uri" @click="(e)=>{e.stopPropagation()}" class="absolute text-black bottom-0 left-0 px-2 bg-white/50 z-10">
                     {{`${(fullscreenImage as ViewImage).aspectRatio?.width}x${(fullscreenImage as ViewImage).aspectRatio?.height}px`}}
                 </div>
                 <img @contextmenu="(e) => {e.preventDefault()}" :src="(fullscreenImage as ViewExternal).uri ? (fullscreenImage as ViewExternal).uri : (fullscreenImage as ViewImage).fullsize" class="max-h-full max-w-full"/>
@@ -38,7 +38,7 @@
                 :style="{'aspect-ratio':`${postDetails.currentThreadView.post.embed.aspectRatio?.width}/${postDetails.currentThreadView.post.embed.aspectRatio?.height}`}"
                 :video-view="postDetails.currentThreadView.post.embed">
                 </video-container>
-                <EmbedExternal v-else-if="hasEmbedGIFMedia" :embed="getEmbedGIFMedia"/>
+                <EmbedExternal v-else-if="hasEmbedGIFMedia" @image-clicked="showImageFullscreen" :embed="getEmbedGIFMedia" :show-fullsize="true"/>
                 <div class="flex h-full w-10 shrink-0 items-center ml-auto">
                     <SlideshowArrow v-if="canIncreaseMediaIndex && !postDetails.isAwaitingFocusData" arrow-direction="Right" @button-clicked="increaseCurrentMediaIndex"/>
                 </div>

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -18,10 +18,12 @@
                     </div>
                 </div>
                 <div v-if="postDetails.isAwaitingFocusData" class="h-full w-full rounded-sm border-0 bg-slate-500 animate-pulse"></div>
-                <div v-else-if="hasImageMedia && !postDetails.isAwaitingFocusData"
+                <!-- <div v-else-if="hasImageMedia && !postDetails.isAwaitingFocusData"
                 class="rounded-sm h-full w-full bg-center bg-contain bg-no-repeat"
                 :style="{'background-image' : 'url('+(getEmbededImageViewImageObjects[currentMediaIndex] as ViewImage).fullsize+')'}">
-                </div>
+                </div> -->
+                <ImageContainer v-else-if="hasImageMedia && !postDetails.isAwaitingFocusData" :show-fullsize="true"
+                :images-to-display="[getEmbededImageViewImageObjects[currentMediaIndex]]" :author="postThread.post.author.handle"/>
                 <video-container v-else-if="isVideoView(postDetails.currentThreadView.post.embed) && !postDetails.isAwaitingFocusData"
                 class="relative flex flex-col max-w-full h-full justify-center p-5"
                 :style="{'aspect-ratio':`${postDetails.currentThreadView.post.embed.aspectRatio?.width}/${postDetails.currentThreadView.post.embed.aspectRatio?.height}`}"
@@ -176,6 +178,7 @@ import { emptyPostThread } from '../../fake-data/dumPostData';
 import { ThreadViewPost } from '@atproto/api/dist/client/types/app/bsky/feed/defs';
 import { getPostThread } from '../../lib/api/Post.vue';
 import { HandleAPIError } from '../../helpers/errors';
+import ImageContainer from '../Utilities/ImageContainer.vue';
 
 export default defineComponent({
     components:{
@@ -183,6 +186,7 @@ export default defineComponent({
         PostInteractionIcons,
         PostThreadView,
         ReplyBreadcrumb,
+        ImageContainer,
         VideoContainer,
         EmbedExternal,
         VerifiedBadge,

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -2,10 +2,15 @@
     <div data-test="post-focus-modal" id="post-focus-modal" tabindex="0"
     class="absolute z-20 h-full w-full flex flex-col sm:flex-row bg-slate-900/90 outline-none overflow-y-auto">
         {{ void "Fullscreen Image" }}
-        <div v-if="isImageFullscreen" @click="hideImageFullscreen" class="absolute flex h-full w-full text-primary items-center justify-center scroll-auto bg-pink-500 bg-contain bg-center bg-no-repeat z-20"
-        :style="{'background-image': 'url('+(fullscreenImageURL)+'s)'}">
-            <img :src="fullscreenImageURL" class="max-h-full max-w-full"/>
-        </div>
+        <Transition>
+            <div v-if="isImageFullscreen" @click="hideImageFullscreen" class="fixed flex h-full w-full text-primary items-center justify-center scroll-auto bg-black/95 bg-contain bg-center bg-no-repeat z-20"
+            :style="{'background-image': 'url('+(fullscreenImage)+'s)'}">
+                <div @click="(e)=>{e.stopPropagation()}" class="absolute text-black bottom-0 left-0 px-2 bg-white/50 z-10">
+                    {{`${(fullscreenImage as ViewImage).aspectRatio?.width}x${(fullscreenImage as ViewImage).aspectRatio?.height}px`}}
+                </div>
+                <img @contextmenu="(e) => {e.preventDefault()}" :src="(fullscreenImage as ViewExternal).uri ? (fullscreenImage as ViewExternal).uri : (fullscreenImage as ViewImage).fullsize" class="max-h-full max-w-full"/>
+            </div>
+        </Transition>
         {{ void "Media Section" }}
         <div class="relative flex flex-col w-full sm:w-3/5 grow min-h-[30rem]">
             <div class="h-10 w-full shrink-0 bg-blacks">
@@ -181,6 +186,7 @@ import { getPostThread } from '../../lib/api/Post.vue';
 import { HandleAPIError } from '../../helpers/errors';
 import ImageContainer from '../Utilities/ImageContainer.vue';
 import SlideshowArrow from '../Utilities/SlideshowArrow.vue';
+import { ViewExternal } from '@atproto/api/dist/client/types/app/bsky/embed/external';
 
 export default defineComponent({
     components:{
@@ -255,8 +261,8 @@ export default defineComponent({
             currentBreadcrumb : [{userName:"Origin",postCID:"this_cid_is_unset"}],
             /**Is a Post image currently being shown at fullscreen size? */
             isImageFullscreen: false,
-            /**URL of image to display at fullscreen size. */
-            fullscreenImageURL : ''
+            /**Object representing image to display at fullscreen size. */
+            fullscreenImage : {} as ViewImage|ViewExternal
         }
     },
     methods:{
@@ -270,13 +276,13 @@ export default defineComponent({
                 // postDetails.setClickedMediaIndex(postDetails.getClickedMediaIndex()-1);
                 this.currentMediaIndex = this.currentMediaIndex-1;
         },
-        showImageFullscreen(imageUrl:string){
-            this.fullscreenImageURL = imageUrl;
+        showImageFullscreen(image:ViewImage|ViewExternal){
+            this.fullscreenImage = image;
             this.isImageFullscreen = true;
         },
         hideImageFullscreen(){
             this.isImageFullscreen = false;
-            this.fullscreenImageURL = '';
+            this.fullscreenImage = {} as ViewImage|ViewExternal;
         },
         hideModal(){
             postDetails.hideFocusModal();
@@ -628,4 +634,13 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
 </style>

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -2,22 +2,20 @@
     <div data-test="post-focus-modal" id="post-focus-modal" tabindex="0"
     class="absolute z-20 h-full w-full flex flex-col sm:flex-row bg-slate-900/90 outline-none overflow-y-auto">
         {{ void "Media Section" }}
-        <div class="flex flex-col w-full sm:w-3/5 grow min-h-[30rem]">
-            {{ void "Close Button" }}
-            <div data-test="postFocusModal-close-button" @click="hideModal" class="flex shrink-0 ml-auto bg-blue-300 py-2 w-10
-                justify-center text-2xl cursor-pointer">
-                <i-mingcute:close-fill/>
+        <div class="relative flex flex-col w-full sm:w-3/5 grow min-h-[30rem]">
+            <div class="h-10 w-full shrink-0 bg-blacks">
+                {{ void "Close Button" }}
+                <div data-test="postFocusModal-close-button" @click="hideModal" class="flex shrink-0 text-primary bg-btn rounded-br items-center aspect-square w-10
+                    justify-center text-2xl cursor-pointer sm:ml-auto sm:rounded-bl sm:rounded-br-none">
+                    <i-mingcute:close-fill/>
+                </div>
             </div>
             {{ void "Media Container" }}
             <div class="flex items-center h-full justify-center overflow-hidden">
-                <div class="flex shrink-0 text-2xl bg-blue-400 w-10">
-                    <div @click="decreaseCurrentMediaIndex"
-                    v-if="canDecreaseMediaIndex"
-                    class="cursor-pointer">
-                        <i-mingcute:left-fill/>
-                    </div>
+                <div class="flex h-full w-10 shrink-0 items-center mr-auto">
+                    <SlideshowArrow v-if="canDecreaseMediaIndex && !postDetails.isAwaitingFocusData" arrow-direction="Left" @button-clicked="decreaseCurrentMediaIndex"/>
                 </div>
-                <div v-if="postDetails.isAwaitingFocusData" class="h-full w-full rounded-sm border-0 bg-slate-500 animate-pulse"></div>
+                <div v-if="postDetails.isAwaitingFocusData" class="h-full w-2/3 rounded-sm border-0 bg-slate-500 animate-pulse mx-auto"></div>
                 <!-- <div v-else-if="hasImageMedia && !postDetails.isAwaitingFocusData"
                 class="rounded-sm h-full w-full bg-center bg-contain bg-no-repeat"
                 :style="{'background-image' : 'url('+(getEmbededImageViewImageObjects[currentMediaIndex] as ViewImage).fullsize+')'}">
@@ -30,12 +28,8 @@
                 :video-view="postDetails.currentThreadView.post.embed">
                 </video-container>
                 <EmbedExternal v-else-if="hasEmbedGIFMedia" :embed="getEmbedGIFMedia"/>
-                <div class="flex shrink-0 text-2xl justify-center bg-blue-400 w-10">
-                    <div @click="increaseCurrentMediaIndex"
-                    v-if="canIncreaseMediaIndex"
-                    class="cursor-pointer">
-                        <i-mingcute:right-fill/>
-                    </div>
+                <div class="flex h-full w-10 shrink-0 items-center ml-auto">
+                    <SlideshowArrow v-if="canIncreaseMediaIndex && !postDetails.isAwaitingFocusData" arrow-direction="Right" @button-clicked="increaseCurrentMediaIndex"/>
                 </div>
             </div>
             <div v-if="postDetails.isAwaitingFocusData" class="flex rounded-lg mx-8 mt-2 mb-8 p-2 h-16 animate-pulse text-sm bg-slate-500/30"></div>
@@ -45,6 +39,7 @@
             <div v-else-if="hasEmbededVideoWithAltText" class="flex rounded-lg mx-8 mt-2 mb-8 p-2 text-sm bg-slate-500/20">
                 <div class="flex min-[300px]:max-h-20 grow overflow-auto">{{ postDetails.currentThreadView.post.embed?.alt }}</div>
             </div>
+            <div v-else class="h-10 w-full shrink-0"></div>
             {{ void "Post Details" }}
             <!-- <div class="flex space-x-2 mx-8 px-2 py-4 ">
                 <div>Comments</div>
@@ -179,6 +174,7 @@ import { ThreadViewPost } from '@atproto/api/dist/client/types/app/bsky/feed/def
 import { getPostThread } from '../../lib/api/Post.vue';
 import { HandleAPIError } from '../../helpers/errors';
 import ImageContainer from '../Utilities/ImageContainer.vue';
+import SlideshowArrow from '../Utilities/SlideshowArrow.vue';
 
 export default defineComponent({
     components:{
@@ -189,6 +185,7 @@ export default defineComponent({
         ImageContainer,
         VideoContainer,
         EmbedExternal,
+        SlideshowArrow,
         VerifiedBadge,
     },
     props:{

--- a/src/components/User/UserFocusModal.vue
+++ b/src/components/User/UserFocusModal.vue
@@ -226,6 +226,10 @@
                                     :title="n.post.embed?.images ? n.post.embed?.images[0].alt : null"
                                     :style="'background-image: url('+(n.post.embed.images ? n.post.embed.images[0].thumb : n.post.embed?.thumbnail)+')'">
                                     </div>
+                                    <!-- Started on using `ImageContainer` for the thumbnails displayed on the media tab
+                                    but realized that it doesn't really make sense when you can just download the image after
+                                    opening the `PostFocusModal`. Maybe I'll change things later. -->
+                                    <!-- <ImageContainer @click="showMediaContent(n)" :images-to-display="n.post.embed.images ? n.post.embed.images.slice(0,1) : [{alt:'',fullsize:n.post.embed?.thumbnail,thumb:n.post.embed?.thumbnail}]" :author="n.post.author.handle"/> -->
                                 </div>
                             </div>
                             <div v-if="!UserFocusModalState.GetCurrentHistoryData().FeedData.cursor"

--- a/src/components/Utilities/EmbedExternal.vue
+++ b/src/components/Utilities/EmbedExternal.vue
@@ -5,10 +5,10 @@
         :class="{'border-b-[1px]':!isTenorGIF}">
             <img v-if="!isTenorGIF" class="absolute w-full h-full object-center object-cover"
             :src="embed && embed.external ? embed.external.thumb : ''"/>
-            <ImageContainer v-else class="absolute w-full h-full object-center object-cover border-0"
-            :title="embed.external.title"
-            :src="embed && embed.external ? embed.external.uri : ''"
-            :images-to-display="embed.external"/>
+            <ImageContainer v-else
+            @image-clicked="img => $emit('imageClicked',img)"
+            @media-click="i => $emit('media-click',i)"
+            :show-fullsize="showFullsize" :images-to-display="embed.external"/>
         </div>
         <div v-if="!isTenorGIF" class="p-2">
             <div class="text-sm font-semibold">{{ embed.external.title}}</div>
@@ -25,11 +25,15 @@
 </template>
 
 <script lang="ts">
-import { View } from '@atproto/api/dist/client/types/app/bsky/embed/external';
+import { View, ViewExternal } from '@atproto/api/dist/client/types/app/bsky/embed/external';
 import { defineComponent, PropType } from 'vue'
 import ImageContainer from './ImageContainer.vue';
+import { ViewImage } from '@atproto/api/dist/client/types/app/bsky/embed/images';
 
 export default defineComponent({
+    components:{
+        ImageContainer
+    },
     props:{
         embed: {
             type: Object as PropType<View>,
@@ -37,10 +41,15 @@ export default defineComponent({
             default(){
                 return {};
             }
+        },
+        /**
+         * Setting this to `true` will cause the `ImageContainer` use the fullsize styling.
+         * Usually set when placing component in `PostFocusModal`.
+         */
+        showFullsize: {
+            type: Boolean,
+            default: false
         }
-    },
-    components:{
-        ImageContainer
     },
     data(){
         return{
@@ -50,6 +59,24 @@ export default defineComponent({
     computed:{
         isTenorGIF(){
             return this.embed.external.uri.includes("tenor.com");
+        }
+    },
+    emits:{
+        /**
+         * Emit event called when clicking on image when in `showFullsize` mode.
+         * Used to show image at "fullscreen" size when in the `PostFocusModal`.
+         * Passes emit sent by `ImageContainer` component.
+         * @param image Object representing the image to display in fullscreen view.
+         */
+        imageClicked(image:ViewImage|ViewExternal){
+            if(image) return true;
+        },
+        /**
+         * Emit event called to open `PostFocusModal` at relevant media index.
+         * @param index The index value representing the media to display.
+        */
+        'media-click'(index:number){
+            if(index>-1) return true;
         }
     }
 })

--- a/src/components/Utilities/ImageContainer.vue
+++ b/src/components/Utilities/ImageContainer.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="Array.isArray(imagesToDisplay)" ref="imageContainer" class="@container relative grid grid-cols-2 grid-flow-row grid-rows-2 w-fulls gap-0.5 border
+    <div v-if="Array.isArray(imagesToDisplay)" ref="imageContainer" class="@container relative grid grid-cols-2 grid-flow-row grid-rows-2 gap-0.5 border
         border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0 h-full"
         :style="[
             (imagesToDisplay?.length === 1 && !imagesToDisplay[0].aspectRatio ? `aspect-ratio: 1 / 1`:''),

--- a/src/components/Utilities/ImageContainer.vue
+++ b/src/components/Utilities/ImageContainer.vue
@@ -1,34 +1,38 @@
 <template>
-    <div v-if="Array.isArray(imagesToDisplay)" ref="imageContainer" class="@container relative grid grid-cols-2 grid-flow-row grid-rows-2 gap-0.5 border
-        border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0 h-full"
-        :style="[
-            (imagesToDisplay?.length === 1 && !imagesToDisplay[0].aspectRatio ? `aspect-ratio: 1 / 1`:''),
-            (imagesToDisplay?.length === 1 && imagesToDisplay[0].aspectRatio ? `aspect-ratio: ${imagesToDisplay[0].aspectRatio?.width} / ${imagesToDisplay[0].aspectRatio?.height}`:''),
-            (imagesToDisplay?.length && imagesToDisplay.length > 1 ? 'aspect-ratio: 16 / 9':'')
-        ]">
-        <SpoilerOverlay :labels="labels" :has-sensitive-content="labels && labels.length>0" :media-type="MediaType.Image"/>
-        <div v-for="(image, index) in imagesToDisplay" @click="showMediaFocusModal(index)" @contextmenu="showOptionsMenu($event, image, author, postText)" class="overflow-hidden"
-            :class="[
-                        (imagesToDisplay?.length === 1 ? 'col-span-2 row-span-2 bg-white/10':''),
-                        (imagesToDisplay?.length === 2 && index === 0 ? 'col-start-1 row-span-2':''),
-                        (imagesToDisplay?.length === 2 && index === 1 ? 'col-start-2 row-span-2':''),
-                        (imagesToDisplay?.length === 3 && index === 0 ? 'col-start-1 row-span-2':''),
-                        showFullsize ? '' : 'cursor-pointer'
-                    ]">
-            <!-- Hide image extension when in "fullsize/fullscreen" mode -->
-            <div v-if="!showFullsize" class="absolute z-[2] rounded-md bottom-1 left-2 p-1 text-xs text-white bg-black/70 select-none">{{ getImageExtension(image.fullsize) }}</div>
-            <div class="h-full w-full bg-center bg-no-repeat"
-            :title="image.alt"
-            :class="(imagesToDisplay?.length === 1 && !image.aspectRatio || showFullsize ? 'bg-contain' : 'bg-cover')"
-                :style="{'background-image': 'url('+(showFullsize ? image.fullsize : image.thumb)+')'}"></div>
+    <div class="h-full w-fulls bg-lime-300s content-center">
+        <div v-if="Array.isArray(imagesToDisplay)" ref="imageContainer" class="@container relative grid border
+            border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0 max-h-full max-w-full" :class="showFullsize ? 'min-w-0' : 'grid-cols-2 grid-flow-row grid-rows-2 gap-0.5'"
+            :style="[
+                (imagesToDisplay?.length === 1 && !imagesToDisplay[0].aspectRatio ? `aspect-ratio: 1 / 1`:''),
+                (imagesToDisplay?.length === 1 && imagesToDisplay[0].aspectRatio && !showFullsize ? `aspect-ratio: ${imagesToDisplay[0].aspectRatio?.width} / ${imagesToDisplay[0].aspectRatio?.height}`:''),
+                // (imagesToDisplay?.length === 1 && imagesToDisplay[0].aspectRatio ? `height: ${imagesToDisplay[0].aspectRatio?.height}px; width: ${imagesToDisplay[0].aspectRatio?.width}px;`:''),
+                (imagesToDisplay?.length && imagesToDisplay.length > 1 ? 'aspect-ratio: 16 / 9':'')
+            ]">
+            <SpoilerOverlay :labels="labels" :has-sensitive-content="labels && labels.length>0" :media-type="MediaType.Image"/>
+            <div v-for="(image, index) in imagesToDisplay" @click="showMediaFocusModal(index)" @contextmenu="showOptionsMenu($event, image, author, postText)" class="overflow-hidden max-h-full max-w-full"
+                :class="[
+                            (imagesToDisplay?.length === 1 ? 'col-span-2 row-span-2 bg-white/10':''),
+                            (imagesToDisplay?.length === 2 && index === 0 ? 'col-start-1 row-span-2':''),
+                            (imagesToDisplay?.length === 2 && index === 1 ? 'col-start-2 row-span-2':''),
+                            (imagesToDisplay?.length === 3 && index === 0 ? 'col-start-1 row-span-2':''),
+                            showFullsize ? 'mx-auto' : 'cursor-pointer'
+                        ]">
+                <!-- Hide image extension when in "fullsize/fullscreen" mode -->
+                <div v-if="!showFullsize" class="absolute z-[2] rounded-md bottom-1 left-2 p-1 text-xs text-white bg-black/70 select-none">{{ getImageExtension(image.fullsize) }}</div>
+                <div v-if="!showFullsize" class="h-full w-full bg-center bg-no-repeat"
+                :title="image.alt"
+                :class="(imagesToDisplay?.length === 1 && !image.aspectRatio || showFullsize ? 'bg-contain' : 'bg-cover')"
+                    :style="{'background-image': 'url('+(showFullsize ? image.fullsize : image.thumb)+')'}"></div>
+                <img v-else @click="$emit('imageClicked', image.fullsize)"  :src="showFullsize ? image.fullsize : image.thumb" class="max-h-full max-w-full bg-contain"/>
+            </div>
         </div>
-    </div>
-    <div v-else ref="imageContainer" class="@container relative w-full gap-0.5 border
-    border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0" :class="showFullsize ? '' : 'cursor-pointer'">
-        <div class="flex justify-center overflow-hidden cursor-pointer w-full h-full" @contextmenu="showOptionsMenu($event, imagesToDisplay, author, postText)">
-            <div class="absolute z-[2] rounded-md bottom-1 left-2 p-1 text-xs text-white bg-black/70 select-none">GIF</div>
-            <!-- GIF -->
-            <img :title="imagesToDisplay?.title" :src="imagesToDisplay?.uri"/>
+        <div v-else ref="imageContainer" class="@container relative w-full gap-0.5 border
+        border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0" :class="showFullsize ? '' : 'cursor-pointer'">
+            <div class="flex justify-center overflow-hidden cursor-pointer w-full h-full" @contextmenu="showOptionsMenu($event, imagesToDisplay, author, postText)">
+                <div class="absolute z-[2] rounded-md bottom-1 left-2 p-1 text-xs text-white bg-black/70 select-none">GIF</div>
+                <!-- GIF -->
+                <img :title="imagesToDisplay?.title" :src="imagesToDisplay?.uri"/>
+            </div>
         </div>
     </div>
 </template>
@@ -142,6 +146,23 @@ export default defineComponent({
                 OptionsMenuState.showOptionMenu(e);
             // }
         },
+    },
+    emits:{
+        /**
+         * Emit event called when clicking on image when in `showFullsize` mode.
+         * Used to show image at "fullscreen" size when in the `PostFocusModal`.
+         * @param url The URL of the image to display in fullscreen view.
+         */
+        imageClicked(url:string){
+            if(url.trim() != '') return true;
+        },
+        /**
+         * Emit event called when clicking on image when not in `showFullsize` mode.
+         * Used to open `PostFocusModal` at relevant media index.
+        */
+        'media-click'(index:number){
+            if(index>-1) return true;
+        }
     },
     data(){
         return{

--- a/src/components/Utilities/ImageContainer.vue
+++ b/src/components/Utilities/ImageContainer.vue
@@ -28,10 +28,10 @@
         </div>
         <div v-else ref="imageContainer" class="@container relative w-full gap-0.5 border
         border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0" :class="showFullsize ? '' : 'cursor-pointer'">
-            <div class="flex justify-center overflow-hidden cursor-pointer w-full h-full" @contextmenu="showOptionsMenu($event, imagesToDisplay, author, postText)">
+            <div v-if="imagesToDisplay" class="flex justify-center overflow-hidden cursor-pointer w-full h-full" @contextmenu="showOptionsMenu($event, imagesToDisplay, author, postText)">
                 <div class="absolute z-[2] rounded-md bottom-1 left-2 p-1 text-xs text-white bg-black/70 select-none">GIF</div>
                 <!-- GIF -->
-                <img :title="imagesToDisplay?.title" :src="imagesToDisplay?.uri"/>
+                <img @click="handleExternalGIFCLick(imagesToDisplay)" :title="imagesToDisplay.title" :src="imagesToDisplay.uri"/>
             </div>
         </div>
     </div>
@@ -161,6 +161,18 @@ export default defineComponent({
                 OptionsMenuState.showOptionMenu(e);
             // }
         },
+        /**
+         * Method used to determine what should be done when clicking on an `ExternalEmbed`
+         * related image. Actions performed are - open image in fullscreen view
+         * (if `showFullsize` is true) or show `PostFocusModal` (usually from `FocusFeedPost`).
+         * @param image Object representing the image to display full-size.
+         */
+        handleExternalGIFCLick(image:ViewExternal){
+            if(this.showFullsize)
+                this.$emit('imageClicked',image);
+            else
+                this.showMediaFocusModal(0);
+        }
     },
     emits:{
         /**

--- a/src/components/Utilities/ImageContainer.vue
+++ b/src/components/Utilities/ImageContainer.vue
@@ -1,28 +1,30 @@
 <template>
-    <div v-if="Array.isArray(imagesToDisplay)" ref="imageContainer" class="@container relative grid grid-cols-2 grid-flow-row grid-rows-2 w-full gap-0.5 border
-        border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0 cursor-pointer"
+    <div v-if="Array.isArray(imagesToDisplay)" ref="imageContainer" class="@container relative grid grid-cols-2 grid-flow-row grid-rows-2 w-fulls gap-0.5 border
+        border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0 h-full"
         :style="[
             (imagesToDisplay?.length === 1 && !imagesToDisplay[0].aspectRatio ? `aspect-ratio: 1 / 1`:''),
             (imagesToDisplay?.length === 1 && imagesToDisplay[0].aspectRatio ? `aspect-ratio: ${imagesToDisplay[0].aspectRatio?.width} / ${imagesToDisplay[0].aspectRatio?.height}`:''),
             (imagesToDisplay?.length && imagesToDisplay.length > 1 ? 'aspect-ratio: 16 / 9':'')
         ]">
         <SpoilerOverlay :labels="labels" :has-sensitive-content="labels && labels.length>0" :media-type="MediaType.Image"/>
-        <div v-for="(image, index) in imagesToDisplay" @click="showMediaFocusModal(index)" @contextmenu="showOptionsMenu($event, image, author, postText)" class="overflow-hidden cursor-pointer"
+        <div v-for="(image, index) in imagesToDisplay" @click="showMediaFocusModal(index)" @contextmenu="showOptionsMenu($event, image, author, postText)" class="overflow-hidden"
             :class="[
                         (imagesToDisplay?.length === 1 ? 'col-span-2 row-span-2 bg-white/10':''),
                         (imagesToDisplay?.length === 2 && index === 0 ? 'col-start-1 row-span-2':''),
                         (imagesToDisplay?.length === 2 && index === 1 ? 'col-start-2 row-span-2':''),
-                        (imagesToDisplay?.length === 3 && index === 0 ? 'col-start-1 row-span-2':'')
+                        (imagesToDisplay?.length === 3 && index === 0 ? 'col-start-1 row-span-2':''),
+                        showFullsize ? '' : 'cursor-pointer'
                     ]">
-            <div class="absolute z-[2] rounded-md bottom-1 left-2 p-1 text-xs text-white bg-black/70 select-none">{{ getImageExtension(image.fullsize) }}</div>
+            <!-- Hide image extension when in "fullsize/fullscreen" mode -->
+            <div v-if="!showFullsize" class="absolute z-[2] rounded-md bottom-1 left-2 p-1 text-xs text-white bg-black/70 select-none">{{ getImageExtension(image.fullsize) }}</div>
             <div class="h-full w-full bg-center bg-no-repeat"
             :title="image.alt"
-            :class="(imagesToDisplay?.length === 1 && !image.aspectRatio ? 'bg-contain' : 'bg-cover')"
-                :style="{'background-image': 'url('+image.thumb+')'}"></div>
+            :class="(imagesToDisplay?.length === 1 && !image.aspectRatio || showFullsize ? 'bg-contain' : 'bg-cover')"
+                :style="{'background-image': 'url('+(showFullsize ? image.fullsize : image.thumb)+')'}"></div>
         </div>
     </div>
     <div v-else ref="imageContainer" class="@container relative w-full gap-0.5 border
-    border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0 cursor-pointer">
+    border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0" :class="showFullsize ? '' : 'cursor-pointer'">
         <div class="flex justify-center overflow-hidden cursor-pointer w-full h-full" @contextmenu="showOptionsMenu($event, imagesToDisplay, author, postText)">
             <div class="absolute z-[2] rounded-md bottom-1 left-2 p-1 text-xs text-white bg-black/70 select-none">GIF</div>
             <!-- GIF -->
@@ -96,7 +98,12 @@ export default defineComponent({
         imagesToDisplay: Object as PropType<ViewImage[]>|PropType<ViewExternal>,
         labels: Object as PropType<Label[]>,
         author: String,
-        postText: String
+        postText: String,
+        /**Setting this to `true` will use the fullsize image instead of the thumbnail.*/
+        showFullsize: {
+            type: Boolean,
+            default: false
+        }
     },
     methods:{
         /**

--- a/src/components/Utilities/ImageContainer.vue
+++ b/src/components/Utilities/ImageContainer.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="h-full w-fulls bg-lime-300s content-center">
+    <div class="h-full content-center">
         <div v-if="Array.isArray(imagesToDisplay)" ref="imageContainer" class="@container relative grid border
             border-outlineLighter rounded-lg overflow-hidden backdrop-blur-0 max-h-full max-w-full" :class="showFullsize ? 'min-w-0' : 'grid-cols-2 grid-flow-row grid-rows-2 gap-0.5'"
             :style="[
@@ -15,7 +15,7 @@
                             (imagesToDisplay?.length === 2 && index === 0 ? 'col-start-1 row-span-2':''),
                             (imagesToDisplay?.length === 2 && index === 1 ? 'col-start-2 row-span-2':''),
                             (imagesToDisplay?.length === 3 && index === 0 ? 'col-start-1 row-span-2':''),
-                            showFullsize ? 'mx-auto' : 'cursor-pointer'
+                            showFullsize ? 'w-full' : 'cursor-pointer'
                         ]">
                 <!-- Hide image extension when in "fullsize/fullscreen" mode -->
                 <div v-if="!showFullsize" class="absolute z-[2] rounded-md bottom-1 left-2 p-1 text-xs text-white bg-black/70 select-none">{{ getImageExtension(image.fullsize) }}</div>
@@ -23,7 +23,7 @@
                 :title="image.alt"
                 :class="(imagesToDisplay?.length === 1 && !image.aspectRatio || showFullsize ? 'bg-contain' : 'bg-cover')"
                     :style="{'background-image': 'url('+(showFullsize ? image.fullsize : image.thumb)+')'}"></div>
-                <img v-else @click="$emit('imageClicked', image.fullsize)"  :src="showFullsize ? image.fullsize : image.thumb" class="max-h-full max-w-full bg-contain"/>
+                <img v-else @click="$emit('imageClicked', image.fullsize)"  :src="showFullsize ? image.fullsize : image.thumb" class="max-h-full max-w-full bg-contain mx-auto"/>
             </div>
         </div>
         <div v-else ref="imageContainer" class="@container relative w-full gap-0.5 border

--- a/src/components/Utilities/ImageContainer.vue
+++ b/src/components/Utilities/ImageContainer.vue
@@ -23,7 +23,7 @@
                 :title="image.alt"
                 :class="(imagesToDisplay?.length === 1 && !image.aspectRatio || showFullsize ? 'bg-contain' : 'bg-cover')"
                     :style="{'background-image': 'url('+(showFullsize ? image.fullsize : image.thumb)+')'}"></div>
-                <img v-else @click="$emit('imageClicked', image.fullsize)"  :src="showFullsize ? image.fullsize : image.thumb" class="max-h-full max-w-full bg-contain mx-auto"/>
+                <img v-else @click="$emit('imageClicked', image)"  :src="showFullsize ? image.fullsize : image.thumb" class="max-h-full max-w-full bg-contain mx-auto"/>
             </div>
         </div>
         <div v-else ref="imageContainer" class="@container relative w-full gap-0.5 border
@@ -40,7 +40,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue'
 import { postDetails } from '../../state/PostDetails.vue';
-import { isViewImage, ViewImage } from '@atproto/api/dist/client/types/app/bsky/embed/images';
+import { ViewImage } from '@atproto/api/dist/client/types/app/bsky/embed/images';
 import { Label } from '@atproto/api/dist/client/types/com/atproto/label/defs';
 import SpoilerOverlay from './SpoilerOverlay.vue';
 import { IOptionMenuItem } from './OptionsMenu.vue';
@@ -50,6 +50,7 @@ import { AppState } from '../../state/AppState.vue';
 //Option Menu icons
 import MdiImageOutline from '~icons/mdi/image-outline';
 import MdiImagePlusOutline from '~icons/mdi/image-plus-outline';
+import MdiOpenInNew from '~icons/mdi/open-in-new';
 import { MediaType } from '../../enums/PostEnums';
 import { ViewExternal } from '@atproto/api/dist/client/types/app/bsky/embed/external';
 import { isTauri } from '@tauri-apps/api/core';
@@ -91,6 +92,19 @@ async function saveImageWithAuthor(image:ViewImage|ViewExternal, author:string|u
         AppState.fileSaveDetails.postText = postText ? postText : '';
     }
     AppState.isSavingMediaModalVisible = true;
+}
+
+/**
+ * Method used to open a specific Image in a new browser tab.
+ * @param imageToShow Object representing the Image to open in the new tab.
+ */
+function OpenImageInNewTab(imageToShow:ViewImage|ViewExternal){
+    if(!imageToShow.uri){//not Tenor GIF
+        open((imageToShow as ViewImage).fullsize);
+    }
+    else{
+        open((imageToShow as ViewExternal).uri);
+    }
 }
 
 export default defineComponent({
@@ -142,7 +156,8 @@ export default defineComponent({
                 OptionsMenuState.currentMenuItems = [
                     {Icon:MdiImagePlusOutline,Label:'Save Image w/ Author Name',Action:function(){saveImageWithAuthor(image,author,postText)}},
                     {Icon:MdiImageOutline,Label:'Save Image',Action:()=>void 0},
-                ] as IOptionMenuItem[]
+                ] as IOptionMenuItem[];
+                if(!isTauri()) OptionsMenuState.currentMenuItems.push({Icon:MdiOpenInNew,Label:'Open Image in New Tab',Action:function(){OpenImageInNewTab(image)}})
                 OptionsMenuState.showOptionMenu(e);
             // }
         },
@@ -151,10 +166,10 @@ export default defineComponent({
         /**
          * Emit event called when clicking on image when in `showFullsize` mode.
          * Used to show image at "fullscreen" size when in the `PostFocusModal`.
-         * @param url The URL of the image to display in fullscreen view.
+         * @param image Object representing the image to display in fullscreen view.
          */
-        imageClicked(url:string){
-            if(url.trim() != '') return true;
+        imageClicked(image:ViewImage|ViewExternal){
+            if(image) return true;
         },
         /**
          * Emit event called when clicking on image when not in `showFullsize` mode.

--- a/src/components/Utilities/SlideshowArrow.vue
+++ b/src/components/Utilities/SlideshowArrow.vue
@@ -1,0 +1,28 @@
+<template>
+    <div class="flex shrink-0 text-2xl justify-center text-primary bg-btn opacity-30 hover:opacity-100
+    transition-opacity rounded-r rounded-l-sm h-10 w-10 items-center ml-auto">
+        <div @click="$emit('buttonClicked')"
+        class="cursor-pointer">
+            <i-mingcute:left-fill v-if="arrowDirection == 'Left'"/>
+            <i-mingcute:right-fill v-if="arrowDirection == 'Right'"/>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue'
+
+export default defineComponent({
+    props:{
+        arrowDirection:{
+            type: String as PropType<'Left'|'Right'|'Up'|'Down'>,
+            required: true
+        }
+    },
+    emits:['buttonClicked'],
+})
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
Update `PostFocusModal` to use `ImageContainer` to display images so the images can be downloaded using the provided context menu.