### PR TITLE
Feature - #154 Navigate images using keyboard

### DIFF
--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -294,11 +294,18 @@ export default defineComponent({
             this.threadNavHistory = [emptyPostThread];
         },
         /**
-         * Method used to navigate through the modal navigation history
+         * Method used to navigate through images held in the modal, using
+         * the Left Arrow or Right Arrow keys, and the modal navigation history
          * if the shortcut Alt + Left Arrow or Alt + Right Arrow is pressed.
          * @param e Key down event.
          */
         onKeyboardShorcutEntered(e:KeyboardEvent){
+            if(e.key == 'ArrowLeft' && !e.repeat){
+                this.decreaseCurrentMediaIndex();
+            }
+            else if(e.key == 'ArrowRight' && !e.repeat){
+                this.increaseCurrentMediaIndex();
+            }
             if(e.key == 'ArrowLeft' && e.altKey && !e.repeat){
                 this.decreaseThreadNavIndex();
             }

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -15,10 +15,12 @@
         <div class="relative flex flex-col w-full sm:w-3/5 grow min-h-[30rem]">
             <div class="h-10 w-full shrink-0 bg-blacks">
                 {{ void "Close Button" }}
-                <div data-test="postFocusModal-close-button" @click="hideModal" class="flex shrink-0 text-primary bg-btn rounded-br items-center aspect-square w-10
-                    justify-center text-2xl cursor-pointer sm:ml-auto sm:rounded-bl sm:rounded-br-none">
+                <SquareButton data-test="postFocusModal-close-button" @click="hideModal"
+                class="text-primary bg-btn !rounded-br aspect-square w-10 text-2xl
+                sm:ml-auto sm:!rounded-tl-none sm:!rounded-r-none"
+                button-padding="0">
                     <i-mingcute:close-fill/>
-                </div>
+                </SquareButton>
             </div>
             {{ void "Media Container" }}
             <div class="flex items-center h-full w-full justify-center overflow-hidden">
@@ -187,6 +189,7 @@ import { HandleAPIError } from '../../helpers/errors';
 import ImageContainer from '../Utilities/ImageContainer.vue';
 import SlideshowArrow from '../Utilities/SlideshowArrow.vue';
 import { ViewExternal } from '@atproto/api/dist/client/types/app/bsky/embed/external';
+import SquareButton from '../Utilities/SquareButton.vue';
 
 export default defineComponent({
     components:{
@@ -199,6 +202,7 @@ export default defineComponent({
         EmbedExternal,
         SlideshowArrow,
         VerifiedBadge,
+        SquareButton,
     },
     props:{
         // /**

--- a/src/components/Utilities/SlideshowArrow.vue
+++ b/src/components/Utilities/SlideshowArrow.vue
@@ -1,18 +1,23 @@
 <template>
-    <div class="flex shrink-0 text-2xl justify-center text-primary bg-btn opacity-30 hover:opacity-100
-    transition-opacity rounded-r rounded-l-sm h-10 w-10 items-center ml-auto">
-        <div @click="$emit('buttonClicked')"
-        class="cursor-pointer">
-            <i-mingcute:left-fill v-if="arrowDirection == 'Left'"/>
-            <i-mingcute:right-fill v-if="arrowDirection == 'Right'"/>
-        </div>
-    </div>
+    <SquareButton @click="$emit('buttonClicked')"
+    class="text-2xl  text-primary bg-btn opacity-30 hover:opacity-100 focus:opacity-100
+    transition-opacity rounded-none h-10 w-10"
+    :class="[{'rounded-l rounded-r-sm' : arrowDirection == 'Left'},
+        {'rounded-r rounded-l-sm ' : arrowDirection == 'Right'}]"
+    button-padding="0">
+        <i-mingcute:left-fill v-if="arrowDirection == 'Left'"/>
+        <i-mingcute:right-fill v-if="arrowDirection == 'Right'"/>
+    </SquareButton>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue'
+import SquareButton from './SquareButton.vue';
 
 export default defineComponent({
+    components:{
+        SquareButton,
+    },
     props:{
         arrowDirection:{
             type: String as PropType<'Left'|'Right'|'Up'|'Down'>,

--- a/src/components/Utilities/SquareButton.vue
+++ b/src/components/Utilities/SquareButton.vue
@@ -1,10 +1,11 @@
 <template>
-    <button class="group flex rounded cursor-pointer justify-center items-center gap-1 transition-colors"
+    <button class="group !border-transparent flex rounded cursor-pointer justify-center items-center gap-1 transition-colors"
     :class="[$attrs.class ? $attrs.class : 'bg-sky-500 hover:bg-sky-700 hover:border-sky-700',
         isDisabled ? '!bg-gray-600 text-gray-400 pointer-events-none select-none' : ''
     ]">
-        <div class="border-2 p-2 border-transparent group-focus:border-feedtypeBtnFocusHighlight
-        w-full"
+        <div class="flex border-2 border-transparent group-focus:border-feedtypeBtnFocusHighlight
+        items-center"
+        :class="`p-${buttonPadding}`"
         style="border-radius: inherit;">
             <slot></slot>
         </div>
@@ -17,9 +18,17 @@ import { defineComponent } from 'vue'
 export default defineComponent({
     name:"SquareButton",
     props:{
+        /**Is the button disabled? */
         isDisabled:{
             type:Boolean
         },
+        /**
+         * The padding to use around the button content. Default is 2 (applies 'p-2').
+         */
+        buttonPadding:{
+            type:String,
+            default:'2'
+        }
     },
     setup () {
         return {}


### PR DESCRIPTION
Adds ability to navigate images displayed in `PostFocusModal` using the arrow keys (left and right) as well as updates the components used for closing the modal and navigating the images so they can be interacted with using the `Tab` and `Space/Enter` keys.