### PR TITLE
Feature - #165 Update `EmbedExternal` desktop interaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.2.1",
         "@tauri-apps/plugin-fs": "^2.2.0",
-        "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-opener": "^2.5.0",
         "@tauri-apps/plugin-sql": "github:tauri-apps/tauri-plugin-sql#v2",
         "@tauri-apps/plugin-store": "^2.2.0",
         "@tauri-apps/plugin-upload": "^2.2.1",
@@ -1454,9 +1454,9 @@
       ]
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.5.0.tgz",
-      "integrity": "sha512-Ldux4ip+HGAcPUmuLT8EIkk6yafl5vK0P0c0byzAKzxJh7vxelVtdPONjfgTm96PbN24yjZNESY8CKo8qniluA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz",
+      "integrity": "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1699,12 +1699,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.2.6.tgz",
-      "integrity": "sha512-bSdkuP71ZQRepPOn8BOEdBKYJQvl6+jb160QtJX/i2H9BF6ZySY/kYljh76N2Ne5fJMQRge7rlKoStYQY5Jq1w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.0.tgz",
+      "integrity": "sha512-B0LShOYae4CZjN8leiNDbnfjSrTwoZakqKaWpfoH6nXiJwt6Rgj6RnVIffG3DoJiKsffRhMkjmBV9VeilSb4TA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.0.0"
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-sql": {
@@ -6631,7 +6631,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.2.1",
     "@tauri-apps/plugin-fs": "^2.2.0",
-    "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-opener": "^2.5.0",
     "@tauri-apps/plugin-sql": "github:tauri-apps/tauri-plugin-sql#v2",
     "@tauri-apps/plugin-store": "^2.2.0",
     "@tauri-apps/plugin-upload": "^2.2.1",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "opener:allow-open-url",
     "core:window:allow-close",
     "core:window:allow-destroy",
     {

--- a/src/components/Feed/FeedEditModal.vue
+++ b/src/components/Feed/FeedEditModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <div data-testid="feed-edit-modal" tabindex="-1" @keydown="trapFocus"
+    <div data-testid="feed-edit-modal" tabindex="-1" @keydown="(e)=>TrapFocus($el,e)"
     class="absolute z-10 flex w-full h-full text-primary bg-slate-800/40 backdrop-blur-sm focus-visible:outline-none">
         <div @click="closeModal" :class="$attrs.class" class="absolute z-10 w-full h-full"></div>
         {{void "Modal Control"}}
@@ -130,7 +130,7 @@ import PillButton from '../Utilities/PillButton.vue';
 import InLaInput from '../Utilities/InLaInput.vue';
 import SquareButton from '../Utilities/SquareButton.vue';
 import UserSearchBar from '../Utilities/UserSearchBar.vue';
-import { AppState, toast } from '../../state/AppState.vue';
+import { AppState, toast, TrapFocus } from '../../state/AppState.vue';
 import { AddFeedToList, FeedState, GenerateUniqueId, GetFeed, GetFeedDataForFeedType, UpdateFeedDetails } from '../../state/FeedList.vue';
 import { HandleAPIError } from '../../helpers/errors.ts';
 import { IFeedColumnSettings, IFeedDescription, IFeedReturnedPostResults } from '../../interfaces/FeedInterfaces.ts';
@@ -188,6 +188,7 @@ export default defineComponent({
             debouncedSearchTerm:'',
             attemptingToCreateFeed: false,
             FeedEnums,
+            TrapFocus,
         }
     },
     methods:{
@@ -371,30 +372,6 @@ export default defineComponent({
                 UpdateFeedDetails(FeedState.selectedFeed,desc,feedResult.data,feedResult.cursor);
             }
             this.closeModal();
-        },
-        /**
-         * Method used to trap tab focus to the modal, preventing
-         * unwanted selection of elements behind it.
-         * Thanks to Ben Nadel at
-         * https://www.bennadel.com/blog/4096-trapping-focus-within-an-element-using-tab-key-navigation-in-javascript.htm.
-         * @param e The Keydown KeyboardEvent that the method is called with.
-         */
-        trapFocus(e: KeyboardEvent){
-            let tabbable = this.$el.querySelectorAll("button, input, select, textarea, [href], [tabindex]:not([tabindex='-1'])") as NodeListOf<HTMLElement>;
-            let target = e.target;
-            if(e.key.toLowerCase() !== 'tab') return; //cancel further actions
-            if(e.shiftKey){
-                if(target == this.$el || target == tabbable[0]){
-                    e.preventDefault();
-                    tabbable[tabbable.length-1].focus();
-                }
-            }
-            else{
-                if(target == tabbable[tabbable.length-1]){
-                    e.preventDefault();
-                    tabbable[0].focus();
-                }
-            }
         },
         closeModal(){
             // AppState.ToggleCreateFeedModal();

--- a/src/components/Utilities/EmbedExternal.vue
+++ b/src/components/Utilities/EmbedExternal.vue
@@ -1,5 +1,6 @@
 <template>
-    <a v-if="!isTenorGIF" tabindex="0"
+    {{ void "External link in Web App and Desktop App" }}
+    <a v-if="!isTenorGIF && !isTauri()" tabindex="0"
     :href="embed.external.uri" target="_blank"
     class="flex flex-col rounded-lg border text-primary transition-colors
     border-outline hover:border-embedHoverBorder hover:bg-embedHoverBG bg-postBG
@@ -20,6 +21,26 @@
             </div>
         </div>
     </a>
+    <div v-else-if="!isTenorGIF && isTauri()" @click="(e) => showOptionsMenu(e, embed.external.uri)" @keyup.enter="showOptionsMenu({} as MouseEvent, 'keypress')" tabindex="0"
+    class="flex flex-col rounded-lg border text-primary transition-colors
+    border-outline hover:border-embedHoverBorder hover:bg-embedHoverBG bg-postBG
+    overflow-hidden text-xs cursor-pointer">
+        <div class="relative border-b-[1px] border-outline aspect-[1.91/1]">
+            <img class="absolute w-full h-full object-center object-cover"
+            :src="embed && embed.external ? embed.external.thumb : ''"/>
+        </div>
+        <div class="p-2 font-normal">
+            <div class="text-sm font-semibold">{{ embed.external.title}}</div>
+            <div class="line-clamp-2" :title="embed.external.description">
+                {{embed.external.description}}
+            </div>
+            <div class="h-[1px] bg-slate-600 my-1"></div>
+            <div class="flex text-nowrap gap-1 items-center">
+                <i-solar:earth-outline class="size-4 shrink-0"/>
+                <div class="overflow-hidden text-ellipsis" :title="embed.external.uri">{{ embed.external.uri }}</div>
+            </div>
+        </div>
+    </div>
     <div v-else @keyup.enter="showEmbedImageInModal" tabindex="0"
     :href="embed.external.uri" target="_blank"
     class="flex flex-col rounded-lg border text-primary transition-colors
@@ -39,6 +60,14 @@ import { View, ViewExternal } from '@atproto/api/dist/client/types/app/bsky/embe
 import { defineComponent, PropType } from 'vue'
 import ImageContainer from './ImageContainer.vue';
 import { ViewImage } from '@atproto/api/dist/client/types/app/bsky/embed/images';
+import { isTauri } from '@tauri-apps/api/core';
+import { OptionsMenuState } from '../../state/OptionsMenuState.vue';
+import { IOptionMenuItem } from './OptionsMenu.vue';
+
+import MingcuteCopyLine from '~icons/mingcute/copy-line';
+import MingcuteWorld2Line from '~icons/mingcute/world-2-line';
+import MingcuteIncognitoModeLine from '~icons/mingcute/incognito-mode-line';
+import { CopyTextToClipboard } from '../../state/AppState.vue';
 
 export default defineComponent({
     components:{
@@ -63,7 +92,7 @@ export default defineComponent({
     },
     data(){
         return{
-            alert
+            isTauri
         }
     },
     computed:{
@@ -95,7 +124,20 @@ export default defineComponent({
         },
         showEmbedImageInModal(){
             this.$emit('media-click',0);
-        }
+        },
+        /**
+         * Shows Options Menu allowing user to perform different actions
+         * relating to the selected embeded content.
+         */
+        showOptionsMenu(e:MouseEvent, linkURL:string){
+            e.preventDefault();
+            OptionsMenuState.currentMenuItems = [
+                {Icon:MingcuteWorld2Line,Label:'Open in Default Browser',Action:function(){alert(`Opened '${linkURL}!''`)}},
+                {Icon:MingcuteIncognitoModeLine,Label:'Open in Default Browser (Private/Incognito)',Action:function(){alert(`Opened '${linkURL}'' secretly!`)}},
+                {Icon:MingcuteCopyLine,Label:'Copy link to clipboard',Action:function(){CopyTextToClipboard(linkURL,'link')}},
+            ] as IOptionMenuItem[]
+            OptionsMenuState.showOptionMenu(e);
+        },
     }
 })
 </script>

--- a/src/components/Utilities/EmbedExternal.vue
+++ b/src/components/Utilities/EmbedExternal.vue
@@ -24,7 +24,7 @@
         </a>
         <div v-else-if="!isTenorGIF && isTauri()" @contextmenu.prevent
         @click="(e) => showOptionsMenu(e, embed.external.uri)"
-        @keyup.enter="showOptionsMenu(mouseEventFromKeyboardEvent, 'keypress')" tabindex="0"
+        @keyup.enter="showOptionsMenu(mouseEventFromKeyboardEvent, embed.external.uri)" tabindex="0"
         class="flex flex-col rounded-lg border text-primary transition-colors
         border-outline hover:border-embedHoverBorder hover:bg-embedHoverBG bg-postBG
         overflow-hidden text-xs cursor-pointer">

--- a/src/components/Utilities/EmbedExternal.vue
+++ b/src/components/Utilities/EmbedExternal.vue
@@ -60,6 +60,10 @@
 </template>
 
 <script lang="ts">
+import MingcuteCopyLine from '~icons/mingcute/copy-line';
+import MingcuteWorld2Line from '~icons/mingcute/world-2-line';
+import MingcuteIncognitoModeLine from '~icons/mingcute/incognito-mode-line';
+
 import { View, ViewExternal } from '@atproto/api/dist/client/types/app/bsky/embed/external';
 import { defineComponent, PropType } from 'vue'
 import ImageContainer from './ImageContainer.vue';
@@ -67,11 +71,16 @@ import { ViewImage } from '@atproto/api/dist/client/types/app/bsky/embed/images'
 import { isTauri } from '@tauri-apps/api/core';
 import { OptionsMenuState } from '../../state/OptionsMenuState.vue';
 import { IOptionMenuItem } from './OptionsMenu.vue';
-
-import MingcuteCopyLine from '~icons/mingcute/copy-line';
-import MingcuteWorld2Line from '~icons/mingcute/world-2-line';
-import MingcuteIncognitoModeLine from '~icons/mingcute/incognito-mode-line';
 import { CopyTextToClipboard } from '../../state/AppState.vue';
+import { openUrl } from '@tauri-apps/plugin-opener';
+
+/**
+ * Method used to open link in the system's default browser.
+ * @param url The URL to open in the default browser.
+ */
+async function OpenLink(url:string){
+    await openUrl(url);
+}
 
 export default defineComponent({
     components:{
@@ -145,8 +154,8 @@ export default defineComponent({
         showOptionsMenu(e:MouseEvent, linkURL:string){
             e.preventDefault();
             OptionsMenuState.currentMenuItems = [
-                {Icon:MingcuteWorld2Line,Label:'Open in Default Browser',Action:function(){alert(`Opened '${linkURL}!''`)}},
-                {Icon:MingcuteIncognitoModeLine,Label:'Open in Default Browser (Private/Incognito)',Action:function(){alert(`Opened '${linkURL}'' secretly!`)}},
+                {Icon:MingcuteWorld2Line,Label:'Open in Default Browser',Action:function(){OpenLink(linkURL)}},
+                // {Icon:MingcuteIncognitoModeLine,Label:'Open in Default Browser (Private/Incognito)',Action:function(){alert(`Opened '${linkURL}'' secretly!`)}},
                 {Icon:MingcuteCopyLine,Label:'Copy link to clipboard',Action:function(){CopyTextToClipboard(linkURL,'link')}},
             ] as IOptionMenuItem[]
             OptionsMenuState.showOptionMenu(e);

--- a/src/components/Utilities/EmbedExternal.vue
+++ b/src/components/Utilities/EmbedExternal.vue
@@ -1,56 +1,60 @@
 <template>
-    {{ void "External link in Web App and Desktop App" }}
-    <a v-if="!isTenorGIF && !isTauri()" tabindex="0"
-    :href="embed.external.uri" target="_blank"
-    class="flex flex-col rounded-lg border text-primary transition-colors
-    border-outline hover:border-embedHoverBorder hover:bg-embedHoverBG bg-postBG
-    overflow-hidden text-xs cursor-pointer">
-        <div class="relative border-b-[1px] border-outline aspect-[1.91/1]">
-            <img class="absolute w-full h-full object-center object-cover"
-            :src="embed && embed.external ? embed.external.thumb : ''"/>
-        </div>
-        <div class="p-2 font-normal">
-            <div class="text-sm font-semibold">{{ embed.external.title}}</div>
-            <div class="line-clamp-2" :title="embed.external.description">
-                {{embed.external.description}}
+    <div>
+        {{ void "External link in Web App and Desktop App" }}
+        <a v-if="!isTenorGIF && !isTauri()" tabindex="0"
+        :href="embed.external.uri" target="_blank"
+        class="flex flex-col rounded-lg border text-primary transition-colors
+        border-outline hover:border-embedHoverBorder hover:bg-embedHoverBG bg-postBG
+        overflow-hidden text-xs cursor-pointer">
+            <div class="relative border-b-[1px] border-outline aspect-[1.91/1]">
+                <img class="absolute w-full h-full object-center object-cover"
+                :src="embed && embed.external ? embed.external.thumb : ''"/>
             </div>
-            <div class="h-[1px] bg-slate-600 my-1"></div>
-            <div class="flex text-nowrap gap-1 items-center">
-                <i-solar:earth-outline class="size-4 shrink-0"/>
-                <div class="overflow-hidden text-ellipsis" :title="embed.external.uri">{{ embed.external.uri }}</div>
+            <div class="p-2 font-normal">
+                <div class="text-sm font-semibold">{{ embed.external.title}}</div>
+                <div class="line-clamp-2" :title="embed.external.description">
+                    {{embed.external.description}}
+                </div>
+                <div class="h-[1px] bg-slate-600 my-1"></div>
+                <div class="flex text-nowrap gap-1 items-center">
+                    <i-solar:earth-outline class="size-4 shrink-0"/>
+                    <div class="overflow-hidden text-ellipsis" :title="embed.external.uri">{{ embed.external.uri }}</div>
+                </div>
+            </div>
+        </a>
+        <div v-else-if="!isTenorGIF && isTauri()" @contextmenu.prevent
+        @click="(e) => showOptionsMenu(e, embed.external.uri)"
+        @keyup.enter="showOptionsMenu(mouseEventFromKeyboardEvent, 'keypress')" tabindex="0"
+        class="flex flex-col rounded-lg border text-primary transition-colors
+        border-outline hover:border-embedHoverBorder hover:bg-embedHoverBG bg-postBG
+        overflow-hidden text-xs cursor-pointer">
+            <div class="relative border-b-[1px] border-outline aspect-[1.91/1]">
+                <img class="absolute w-full h-full object-center object-cover"
+                :src="embed && embed.external ? embed.external.thumb : ''"/>
+            </div>
+            <div class="p-2 font-normal">
+                <div class="text-sm font-semibold">{{ embed.external.title}}</div>
+                <div class="line-clamp-2" :title="embed.external.description">
+                    {{embed.external.description}}
+                </div>
+                <div class="h-[1px] bg-slate-600 my-1"></div>
+                <div class="flex text-nowrap gap-1 items-center">
+                    <i-solar:earth-outline class="size-4 shrink-0"/>
+                    <div class="overflow-hidden text-ellipsis" :title="embed.external.uri">{{ embed.external.uri }}</div>
+                </div>
             </div>
         </div>
-    </a>
-    <div v-else-if="!isTenorGIF && isTauri()" @click="(e) => showOptionsMenu(e, embed.external.uri)" @keyup.enter="showOptionsMenu({} as MouseEvent, 'keypress')" tabindex="0"
-    class="flex flex-col rounded-lg border text-primary transition-colors
-    border-outline hover:border-embedHoverBorder hover:bg-embedHoverBG bg-postBG
-    overflow-hidden text-xs cursor-pointer">
-        <div class="relative border-b-[1px] border-outline aspect-[1.91/1]">
-            <img class="absolute w-full h-full object-center object-cover"
-            :src="embed && embed.external ? embed.external.thumb : ''"/>
-        </div>
-        <div class="p-2 font-normal">
-            <div class="text-sm font-semibold">{{ embed.external.title}}</div>
-            <div class="line-clamp-2" :title="embed.external.description">
-                {{embed.external.description}}
+        <div v-else @keyup.enter="showEmbedImageInModal" tabindex="0"
+        :href="embed.external.uri" target="_blank"
+        class="flex flex-col rounded-lg border text-primary transition-colors
+        border-outline hover:bg-embedHoverBG bg-postBG
+        overflow-hidden text-xs cursor-pointer">
+            <div class="relative border-outline aspect-[1.91/1]">
+                <ImageContainer
+                @image-clicked="img => $emit('imageClicked',img)"
+                @media-click="i => $emit('media-click',i)"
+                :show-fullsize="showFullsize" :images-to-display="embed.external"/>
             </div>
-            <div class="h-[1px] bg-slate-600 my-1"></div>
-            <div class="flex text-nowrap gap-1 items-center">
-                <i-solar:earth-outline class="size-4 shrink-0"/>
-                <div class="overflow-hidden text-ellipsis" :title="embed.external.uri">{{ embed.external.uri }}</div>
-            </div>
-        </div>
-    </div>
-    <div v-else @keyup.enter="showEmbedImageInModal" tabindex="0"
-    :href="embed.external.uri" target="_blank"
-    class="flex flex-col rounded-lg border text-primary transition-colors
-    border-outline hover:bg-embedHoverBG bg-postBG
-    overflow-hidden text-xs cursor-pointer">
-        <div class="relative border-outline aspect-[1.91/1]">
-            <ImageContainer
-            @image-clicked="img => $emit('imageClicked',img)"
-            @media-click="i => $emit('media-click',i)"
-            :show-fullsize="showFullsize" :images-to-display="embed.external"/>
         </div>
     </div>
 </template>
@@ -98,7 +102,16 @@ export default defineComponent({
     computed:{
         isTenorGIF(){
             return this.embed.external.uri.includes("tenor.com");
-        }
+        },
+        /**
+         * Creates a `MouseEvent` from the `KeyboardEvent` used to "click" the `EmbedExternal` element.
+         * Used to position the displayed `OptionsMenu`.
+         * @returns The created `MouseEvent` object.
+         */
+        mouseEventFromKeyboardEvent():MouseEvent{
+            let elRect = (this.$el as HTMLElement).getBoundingClientRect();
+            return ({clientX:elRect.x, clientY:elRect.y, preventDefault:()=>{}} as MouseEvent);
+        },
     },
     emits:{
         /**

--- a/src/components/Utilities/OptionsMenu.vue
+++ b/src/components/Utilities/OptionsMenu.vue
@@ -1,15 +1,15 @@
 <template>
-    <div class="absolute flex w-full h-full" @contextmenu.prevent>
-        <!-- <div class="w-full h-full z-10 bg-red-500"> -->
-            <div id="options-btn-menu" class="absolute flex flex-col rounded z-[100] p-1 bg-slate-800 border
-            border-slate-600 *:divide-slate-500 text-xs space-y-1 drop-shadow-md-harder top-[-1000px]">
-                <div v-for="mi in OptionsMenuState.currentMenuItems" @click="performAction(mi.Action)" @contextmenu.prevent
-                class="flex rounded-sm py-0.5 px-1 divide-x-[1px] items-center hover:bg-white/20 cursor-pointer">
-                    <div class="pr-1 text-base" :class="mi.IconStyle"><component :is="mi.Icon"/></div>
-                    <div class="pl-2" :class="mi.LabelStyle">{{ mi.Label }}</div>
-                </div>
-            </div>
-        <!-- </div> -->
+    <div class="absolute flex w-full h-full" @contextmenu.prevent @keydown="(e) => TrapFocus($el,e)">
+        <div id="options-btn-menu" :tabindex="-1"
+        class="absolute flex flex-col rounded z-[100] p-1 bg-slate-800 border
+        border-slate-600 *:divide-slate-500 text-xs space-y-1 drop-shadow-md-harder top-[-1000px] focus-visible:outline-none">
+            <button v-for="mi in OptionsMenuState.currentMenuItems" @click="performAction(mi.Action)" @contextmenu.prevent
+            class="flex rounded-sm py-0.5 px-1 divide-x-[1px] items-center hover:bg-white/20 shadow-none cursor-pointer
+            focus-visible:border-searchbarFocusHightlight">
+                <div class="pr-1 text-base" :class="mi.IconStyle"><component :is="mi.Icon"/></div>
+                <div class="pl-2" :class="mi.LabelStyle">{{ mi.Label }}</div>
+            </button>
+        </div>
         <div @click="hideMenu" @contextmenu="hideMenu" class="z-[90] w-full h-full"></div>
     </div>
 </template>
@@ -17,6 +17,7 @@
 <script lang="ts">
 import { defineComponent, FunctionalComponent } from 'vue'
 import { OptionsMenuState } from '../../state/OptionsMenuState.vue';
+import { TrapFocus } from '../../state/AppState.vue';
 
 export interface IOptionMenuItem{
     Icon: FunctionalComponent,
@@ -30,6 +31,7 @@ export default defineComponent({
     data(){
         return{
             OptionsMenuState,
+            TrapFocus,
         }
     },
     methods:{
@@ -41,6 +43,10 @@ export default defineComponent({
             action();
             OptionsMenuState.hideOptionMenu();
         }
+    },
+    mounted(){
+        // console.log(((this.$el as HTMLElement).children[0] as HTMLElement));
+        // ((this.$el as HTMLElement).children[0] as HTMLElement).focus();
     }
 })
 </script>

--- a/src/components/Utilities/OptionsMenu.vue
+++ b/src/components/Utilities/OptionsMenu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="absolute flex w-full h-full" @contextmenu.prevent @keydown="(e) => TrapFocus($el,e)">
+    <div class="absolute flex w-full h-full" @contextmenu.prevent @keyup="handleKeyup" @keydown="(e) => TrapFocus($el,e)">
         <div id="options-btn-menu" :tabindex="-1"
         class="absolute flex flex-col rounded z-[100] p-1 bg-slate-800 border
         border-slate-600 *:divide-slate-500 text-xs space-y-1 drop-shadow-md-harder top-[-1000px] focus-visible:outline-none">
@@ -42,6 +42,14 @@ export default defineComponent({
         performAction(action:Function){
             action();
             OptionsMenuState.hideOptionMenu();
+        },
+        /**
+         * Method used to close the menu when the Escape Key is
+         * pressed.
+         * @param e The `KeyboardEvent` that called the handler.
+         */
+        handleKeyup(e:KeyboardEvent){
+            if(e.key.toLowerCase() == 'escape') this.hideMenu(e);
         }
     },
     mounted(){

--- a/src/state/AppState.vue
+++ b/src/state/AppState.vue
@@ -55,6 +55,32 @@ export function CopyTextToClipboard(textToCopy:string, copyAction:'text'|'link' 
     }
 }
 
+/**
+ * Method used to trap tab focus to an element, preventing
+ * unwanted selection of elements behind it.
+ * Thanks to Ben Nadel at
+ * https://www.bennadel.com/blog/4096-trapping-focus-within-an-element-using-tab-key-navigation-in-javascript.htm.
+ * @param el The element to trap focus in.
+ * @param e The Keydown KeyboardEvent that the method is called with.
+ */
+export function TrapFocus(el:HTMLElement, e: KeyboardEvent){
+    let tabbable = el.querySelectorAll("button, input, select, textarea, [href], [tabindex]:not([tabindex='-1'])") as NodeListOf<HTMLElement>;
+    let target = e.target;
+    if(e.key.toLowerCase() !== 'tab') return; //cancel further actions
+    if(e.shiftKey){
+        if(target == el || target == tabbable[0]){
+            e.preventDefault();
+            tabbable[tabbable.length-1].focus();
+        }
+    }
+    else{
+        if(target == tabbable[tabbable.length-1]){
+            e.preventDefault();
+            tabbable[0].focus();
+        }
+    }
+}
+
 export default{
     name:"AppState"
 }

--- a/src/state/AppState.vue
+++ b/src/state/AppState.vue
@@ -17,6 +17,44 @@ export const toast = {
     removeAllGroups: () => ToastEventBus.emit('remove-all-groups'),
 };
 
+/**
+ * Copies the passed in text value to the User's clipboard.
+ * @param textToCopy The text to copy.
+ * @param copyAction Affects the message displayed when copying is successful.
+ * Default is 'text' (e.g. Text Copied).
+ */
+export function CopyTextToClipboard(textToCopy:string, copyAction:'text'|'link' = 'text'){
+    if(navigator.clipboard){//Modern method - requires app to serve page(s) over HTTPS
+        try{
+            navigator.clipboard.writeText(textToCopy ? textToCopy : '');
+            toast.add({summary:`${copyAction[0].toUpperCase()+copyAction.substring(1)} Copied`,
+                severity:'success', group:'bc', life:1000});
+        }
+        catch(err){
+            console.error('Unable to copy to clipboard', err);
+            toast.add({summary:`Error copying ${copyAction}`,severity:'error', group:'bc', life:1000});
+        }
+    }
+    else{
+        //Unsecured text copy
+        const textArea = document.createElement("textarea");
+        textArea.value = textToCopy ? textToCopy : '';
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        try{
+            document.execCommand('copy');
+            toast.add({summary:`${copyAction[0].toUpperCase()+copyAction.substring(1)} Copied`,
+                severity:'success', group:'bc', life:1000});
+        }
+        catch(err){
+            console.error('Unable to copy to clipboard', err);
+            toast.add({summary:`Error copying ${copyAction}`,severity:'error', group:'bc', life:1000});
+        }
+        document.body.removeChild(textArea);
+    }
+}
+
 export default{
     name:"AppState"
 }

--- a/src/state/OptionsMenuState.vue
+++ b/src/state/OptionsMenuState.vue
@@ -21,6 +21,7 @@ export const OptionsMenuState = reactive({
                 let pos = this.getSafeMenuPosition(event);
                 menu.style.top = pos.y+'px';
                 menu.style.left = pos.x+'px';
+                menu.focus();
             }
         }, 2);
     },


### PR DESCRIPTION
- Adds ability for the `EmbedExternal` component to be interacted with when using the Desktop/Tauri version of the app. Allows the user to copy the associated web URL or open it in the system's default browser. 
- Also updated `OptionsMenu` so that you can interact with it usng tabbing + the Enter Key.