### PR TITLE
Feature/186 update postfocusmodal control layout

### DIFF
--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -12,9 +12,9 @@
                 <img @contextmenu="(e) => {e.preventDefault()}" :src="(fullscreenImage as ViewExternal).uri ? (fullscreenImage as ViewExternal).uri : (fullscreenImage as ViewImage).fullsize" class="max-h-full max-w-full"/>
             </div>
         </Transition>
-        <div class="sticky sm:absolute top-0 z-20 flex justify-center h-10 w-full sm:w-auto shrink-0 bg-postFocusBG sm:bg-transparent">
+        <div class="sticky sm:absolute top-0 z-20 flex justify-center h-10 w-full sm:w-auto shrink-0 bg-postFocusBG sm:bg-transparent border-b border-outline">
             {{ void "Close Button" }}
-            <div class="self-center flex justify-between w-full px-4 sm:px-0">
+            <div class="self-center flex justify-between w-full h-full px-4 py-2 sm:px-0">
                 <div @click="scrollToTopOfModal" class="flex rounded-lg cursor-pointer bg-btn items-center py-1 px-3 text-primary sm:hidden"><i-mdi:format-vertical-align-top/></div>
                 <div v-if="hasImageMedia" @click="showImageFullscreen(getEmbededImageViewImageObjects[currentMediaIndex])"
                 class="flex rounded-lg cursor-pointer bg-btn items-center px-3 text-primary sm:hidden">View Image</div>
@@ -71,7 +71,7 @@
             </div> -->
         </div>
         {{ void "Comments Section" }}
-        <div class="flex flex-col w-full sm:w-2/5 shrink-0 sm:max-w-96 bg-postFocusBG grow">
+        <div class="flex flex-col w-full sm:w-2/5 shrink-0 sm:max-w-96 bg-postFocusBG grow sm:ml-auto">
             {{ void "Focused Post Loading Placeholder/Skeleton" }}
             <div v-if="postDetails.isAwaitingFocusData || isChangingThreadContext" class="flex flex-col rounded bg-slate-400s p-4 pb-2 w-full">
                 <div class="animate-pulse flex flex-col w-full overflow-hidden gap-1">
@@ -98,7 +98,7 @@
                     </div>
                 </div>
             </div>
-            <div v-else class="p-4 pb-1 sticky top-8 sm:top-0 z-10 bg-postFocusBG border-b border-outline shadow-lg sm:shadow-none shadow-primary/10">
+            <div v-else class="p-4 pb-1 sticky top-10 sm:top-0 z-10 bg-postFocusBG border-b border-outline shadow-lg sm:shadow-none shadow-postFocusModalDetailsShadow/10">
                 {{ void "User Info/Actions" }}
                 <div class="flex gap-1">
                     <AvatarRound :avatar="postDetails.currentThreadView.post.author.avatar"
@@ -139,7 +139,7 @@
                 </div>
             </div>
             {{ void "post reply input" }}
-            <div class="px-4 py-4"><PostReplyInput/></div>
+            <div v-if="false" class="px-4 py-4"><PostReplyInput/></div>
             {{ void "Replies Loading Placeholder/Skeleton" }}
             <div v-if="postDetails.isAwaitingFocusData" class="flex flex-col rounded bg-slate-400s pt-4 px-4 w-full">
                 <div class="animate-pulse flex w-full overflow-hidden gap-2">
@@ -535,6 +535,12 @@ export default defineComponent({
             if((postDetails.currentThreadView.post.embed &&
             postDetails.currentThreadView.post.embed.external &&
             AppBskyEmbedExternal.isView(postDetails.currentThreadView.post.embed)))
+                return true;
+            return false;
+        },
+        /**Checks to see if the current post contains any media (Image, GIF or Video). */
+        hasAnyMedia(){
+            if(this.hasImageMedia || this.hasEmbedGIFMedia || isVideoView(postDetails.currentThreadView.post.embed))
                 return true;
             return false;
         },

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <div data-test="post-focus-modal" id="post-focus-modal" tabindex="0"
+    <div data-test="post-focus-modal" id="post-focus-modal" tabindex="0" @scroll.passive="toggleScrollToTop"
     class="absolute z-20 h-full w-full flex flex-col sm:flex-row bg-slate-900/90 outline-none overflow-y-auto">
         {{ void "Fullscreen Image" }}
         <Transition>
@@ -15,9 +15,10 @@
         <div class="sticky sm:absolute top-0 z-20 flex justify-center h-10 w-full sm:w-auto shrink-0 bg-postFocusBG sm:bg-transparent border-b border-outline">
             {{ void "Close Button" }}
             <div class="self-center flex justify-between w-full h-full px-4 py-2 sm:px-0">
-                <div @click="scrollToTopOfModal" class="flex rounded-lg cursor-pointer bg-btn items-center py-1 px-3 text-primary sm:hidden"><i-mdi:format-vertical-align-top/></div>
+                <div @click="isScrollToTopVisible && scrollToTopOfModal()" class="flex rounded-lg cursor-pointer bg-btn items-center py-1 px-3 text-primary sm:hidden transition-opacity"
+                :style="[isScrollToTopVisible ? {'opacity':'100%'} : {'opacity':'0%'}]"><i-mdi:format-vertical-align-top/></div>
                 <div v-if="hasImageMedia" @click="showImageFullscreen(getEmbededImageViewImageObjects[currentMediaIndex])"
-                class="flex rounded-lg cursor-pointer bg-btn items-center px-3 text-primary sm:hidden">View Image</div>
+                class="flex rounded-lg cursor-pointer bg-btn items-center px-3 text-primary text-sm sm:hidden">View Image</div>
                 <div @click="hideModal" class="flex rounded-lg cursor-pointer bg-btn px-3 items-center text-primary sm:hidden"><i-mingcute:close-fill/></div>
             </div>
             <SquareButton data-test="postFocusModal-close-button" @click="hideModal"
@@ -70,6 +71,7 @@
                 <div>Share</div>
             </div> -->
         </div>
+        <div v-else @click="hideModal" class="w-full h-full"></div>
         {{ void "Comments Section" }}
         <div class="flex flex-col w-full sm:w-2/5 shrink-0 sm:max-w-96 bg-postFocusBG grow sm:ml-auto">
             {{ void "Focused Post Loading Placeholder/Skeleton" }}
@@ -203,6 +205,7 @@ import { ViewExternal } from '@atproto/api/dist/client/types/app/bsky/embed/exte
 import SquareButton from '../Utilities/SquareButton.vue';
 import RichPostTextBsky from '../Utilities/RichPostTextBsky.vue';
 import { Record } from '@atproto/api/dist/client/types/app/bsky/feed/post';
+import { debounce } from '../../helpers/debouncer';
 
 export default defineComponent({
     components:{
@@ -280,7 +283,9 @@ export default defineComponent({
             /**Is a Post image currently being shown at fullscreen size? */
             isImageFullscreen: false,
             /**Object representing image to display at fullscreen size. */
-            fullscreenImage : {} as ViewImage|ViewExternal
+            fullscreenImage : {} as ViewImage|ViewExternal,
+            /**Is the "scroll to top" button currently visible? */
+            isScrollToTopVisible:false,
         }
     },
     methods:{
@@ -509,7 +514,12 @@ export default defineComponent({
         scrollToTopOfModal(){
             let mainContainer = document.getElementById('post-focus-modal');
             if(mainContainer) mainContainer.scrollBy({top:-mainContainer.scrollTop,behavior:'smooth'});
-        }
+        },
+        /**
+         * Method used to scroll back to the top of a Feed list. Defined in the
+         * "created()" section.
+         */
+        toggleScrollToTop(e:Event){},
     },
     computed:{
         /**Checks to see if the current post contains any image media. */
@@ -652,6 +662,17 @@ export default defineComponent({
                 return true;
             return false;
         },
+    },
+    created(){
+        /**Defines actions for the `toggleScrollToTop` function */
+        this.toggleScrollToTop = debounce(e => {
+            if((e.target as HTMLElement).scrollTop<20){
+                this.isScrollToTopVisible = false;
+            }
+            else{
+                this.isScrollToTopVisible = true;
+            }
+        },200);
     },
     mounted(){
         //Add keyboard+mouse shortcut listener

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -3,7 +3,8 @@
     class="absolute z-20 h-full w-full flex flex-col sm:flex-row bg-slate-900/90 outline-none overflow-y-auto">
         {{ void "Fullscreen Image" }}
         <Transition>
-            <div v-if="isImageFullscreen" @click="hideImageFullscreen" class="fixed flex h-full w-full text-primary items-center justify-center scroll-auto bg-black/95 bg-contain bg-center bg-no-repeat z-20"
+            <div v-if="isImageFullscreen" @click="hideImageFullscreen" class="fixed flex h-full w-full text-primary items-center justify-center scroll-auto bg-black/95
+            bg-contain bg-center bg-no-repeat z-30"
             :style="{'background-image': 'url('+(fullscreenImage)+'s)'}">
                 <div v-if="!(fullscreenImage as ViewExternal).uri" @click="(e)=>{e.stopPropagation()}" class="absolute text-black bottom-0 left-0 px-2 bg-white/50 z-10">
                     {{`${(fullscreenImage as ViewImage).aspectRatio?.width}x${(fullscreenImage as ViewImage).aspectRatio?.height}px`}}
@@ -11,23 +12,32 @@
                 <img @contextmenu="(e) => {e.preventDefault()}" :src="(fullscreenImage as ViewExternal).uri ? (fullscreenImage as ViewExternal).uri : (fullscreenImage as ViewImage).fullsize" class="max-h-full max-w-full"/>
             </div>
         </Transition>
-        {{ void "Media Section" }}
-        <div class="relative flex flex-col w-full sm:w-3/5 grow min-h-[30rem]">
-            <div class="h-10 w-full shrink-0 bg-blacks">
-                {{ void "Close Button" }}
-                <SquareButton data-test="postFocusModal-close-button" @click="hideModal"
-                class="text-primary bg-btn !rounded-br aspect-square w-10 text-2xl
-                sm:ml-auto sm:!rounded-tl-none sm:!rounded-r-none"
-                button-padding="0">
-                    <i-mingcute:close-fill/>
-                </SquareButton>
+        <div class="sticky sm:absolute top-0 z-20 flex justify-center h-10 w-full sm:w-auto shrink-0 bg-postFocusBG sm:bg-transparent">
+            {{ void "Close Button" }}
+            <div class="self-center flex justify-between w-full px-4 sm:px-0">
+                <div @click="scrollToTopOfModal" class="flex rounded-lg cursor-pointer bg-btn items-center py-1 px-3 text-primary sm:hidden"><i-mdi:format-vertical-align-top/></div>
+                <div v-if="hasImageMedia" @click="showImageFullscreen(getEmbededImageViewImageObjects[currentMediaIndex])"
+                class="flex rounded-lg cursor-pointer bg-btn items-center px-3 text-primary sm:hidden">View Image</div>
+                <div @click="hideModal" class="flex rounded-lg cursor-pointer bg-btn px-3 items-center text-primary sm:hidden"><i-mingcute:close-fill/></div>
             </div>
+            <SquareButton data-test="postFocusModal-close-button" @click="hideModal"
+            class="text-primary bg-btn !rounded-br aspect-square w-10 text-2xl
+            ml-auto sm:!rounded-tl-none sm:!rounded-r-none hidden sm:block"
+            button-padding="0">
+                <i-mingcute:close-fill/>
+            </SquareButton>
+        </div>
+        {{ void "Media Section" }}
+        <div v-if="hasImageMedia || hasEmbedGIFMedia || isVideoView(postDetails.currentThreadView.post.embed)"
+        class="relative flex flex-col w-full sm:w-3/5 grow min-h-[30rem]">
             {{ void "Media Container" }}
-            <div class="flex items-center h-full w-full justify-center overflow-hidden">
+            <div class="flex items-center h-full w-full justify-center overflow-hidden p-5 sm:pt-10">
                 <div class="flex h-full w-10 shrink-0 items-center mr-auto">
                     <SlideshowArrow v-if="canDecreaseMediaIndex && !postDetails.isAwaitingFocusData" arrow-direction="Left" @button-clicked="decreaseCurrentMediaIndex"/>
                 </div>
-                <div v-if="postDetails.isAwaitingFocusData" class="h-full w-2/3 rounded-sm border-0 bg-slate-500 animate-pulse mx-auto"></div>
+                <div v-if="postDetails.isAwaitingFocusData" class="h-full w-2/3">
+                    <div class="h-full w-full rounded-sm border-0 bg-slate-500 animate-pulse mx-auto"></div>
+                </div>
                 <!-- <div v-else-if="hasImageMedia && !postDetails.isAwaitingFocusData"
                 class="rounded-sm h-full w-full bg-center bg-contain bg-no-repeat"
                 :style="{'background-image' : 'url('+(getEmbededImageViewImageObjects[currentMediaIndex] as ViewImage).fullsize+')'}">
@@ -45,11 +55,11 @@
                     <SlideshowArrow v-if="canIncreaseMediaIndex && !postDetails.isAwaitingFocusData" arrow-direction="Right" @button-clicked="increaseCurrentMediaIndex"/>
                 </div>
             </div>
-            <div v-if="postDetails.isAwaitingFocusData" class="flex rounded-lg mx-8 mt-2 mb-8 p-2 h-16 animate-pulse text-sm bg-slate-500/30"></div>
-            <div v-else-if="hasEmbededImagesWithAltText" class="flex rounded-lg mx-8 mt-2 mb-8 p-2 text-sm bg-slate-500/20">
+            <div v-if="postDetails.isAwaitingFocusData" class="flex rounded-lg mx-8 mb-8 p-2 h-16 animate-pulse text-sm bg-slate-500/30"></div>
+            <div v-else-if="hasEmbededImagesWithAltText" class="flex rounded-lg mx-8 mb-8 p-2 text-sm bg-slate-500/20">
                 <div class="flex min-[300px]:max-h-20 grow overflow-auto">{{ getEmbededImageAltText }}</div>
             </div>
-            <div v-else-if="hasEmbededVideoWithAltText" class="flex rounded-lg mx-8 mt-2 mb-8 p-2 text-sm bg-slate-500/20">
+            <div v-else-if="hasEmbededVideoWithAltText" class="flex rounded-lg mx-8 mb-8 p-2 text-sm bg-slate-500/20">
                 <div class="flex min-[300px]:max-h-20 grow overflow-auto">{{ postDetails.currentThreadView.post.embed?.alt }}</div>
             </div>
             <div v-else class="h-10 w-full shrink-0"></div>
@@ -61,9 +71,9 @@
             </div> -->
         </div>
         {{ void "Comments Section" }}
-        <div class="flex flex-col w-full sm:w-2/5 shrink-0 sm:max-w-96 bg-postFocusBG">
+        <div class="flex flex-col w-full sm:w-2/5 shrink-0 sm:max-w-96 bg-postFocusBG grow">
             {{ void "Focused Post Loading Placeholder/Skeleton" }}
-            <div v-if="postDetails.isAwaitingFocusData" class="flex flex-col rounded bg-slate-400s p-4 pb-2 w-full">
+            <div v-if="postDetails.isAwaitingFocusData || isChangingThreadContext" class="flex flex-col rounded bg-slate-400s p-4 pb-2 w-full">
                 <div class="animate-pulse flex flex-col w-full overflow-hidden gap-1">
                     <div class="flex gap-2 mb-1">
                         <div class="drop-shadow-md">
@@ -88,8 +98,8 @@
                     </div>
                 </div>
             </div>
-            {{ void "User Info/Actions" }}
-            <div v-if="!postDetails.isAwaitingFocusData" class="p-4 pb-1">
+            <div v-else class="p-4 pb-1 sticky top-8 sm:top-0 z-10 bg-postFocusBG border-b border-outline shadow-lg sm:shadow-none shadow-primary/10">
+                {{ void "User Info/Actions" }}
                 <div class="flex gap-1">
                     <AvatarRound :avatar="postDetails.currentThreadView.post.author.avatar"
                     :did="postDetails.currentThreadView.post.author.did"
@@ -114,7 +124,8 @@
                 {{ void "Post Content - Text" }}
                 <RichPostTextBsky data-test="postFocusModal-text" class="text-sm pt-2 text-primary"
                 :post-text="(postDetails.currentThreadView.post.record as Record).text"
-                :post-facets="(postDetails.currentThreadView.post.record as Record).facets"/>
+                :post-facets="(postDetails.currentThreadView.post.record as Record).facets"
+                :is-changing-thread-context="isChangingThreadContext"/>
                 {{ void "Post Metadata" }}
                 <div class="flex flex-col gap-2">
                     <div class="flex flex-wrap gap-1s leading-5 py-0.5 border-b-[1px] border-slate-600">
@@ -128,7 +139,7 @@
                 </div>
             </div>
             {{ void "post reply input" }}
-            <div class="px-4"><PostReplyInput/></div>
+            <div class="px-4 py-4"><PostReplyInput/></div>
             {{ void "Replies Loading Placeholder/Skeleton" }}
             <div v-if="postDetails.isAwaitingFocusData" class="flex flex-col rounded bg-slate-400s pt-4 px-4 w-full">
                 <div class="animate-pulse flex w-full overflow-hidden gap-2">
@@ -381,7 +392,7 @@ export default defineComponent({
                 postDetails.currentThreadView = this.threadNavHistory[this.threadNavIndex];
                 setTimeout(() => {
                     this.isChangingThreadContext = false;
-                }, 1);
+                }, 300);//timeout used to refresh `RichPostTextBsky` component with updated content
             }
         },
         /**
@@ -491,6 +502,13 @@ export default defineComponent({
                 this.currentBreadcrumb.unshift({userName:parentThread.post.author.displayName, postCID:parentThread?.post.cid});
                 this.discoverBreadcrumbs(parentThread?.post.record.reply.parent.cid,parentThread);
             }
+        },
+        /**
+         * Method used to scroll to top of `PostFocusModal`.
+         */
+        scrollToTopOfModal(){
+            let mainContainer = document.getElementById('post-focus-modal');
+            if(mainContainer) mainContainer.scrollBy({top:-mainContainer.scrollTop,behavior:'smooth'});
         }
     },
     computed:{
@@ -543,7 +561,7 @@ export default defineComponent({
          * Checks to see if the current post contains a video, and if
          * it has any descriptive ALT text.
          */
-         hasEmbededVideoWithAltText(){
+        hasEmbededVideoWithAltText(){
             if(postDetails.currentThreadView.post.embed &&
             isVideoView(postDetails.currentThreadView.post.embed) &&
             (postDetails.currentThreadView.post.embed as ViewVideo).alt &&

--- a/src/components/Post/PostThreadView.vue
+++ b/src/components/Post/PostThreadView.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- <ReplyBreadcrumb class="px-4"/> -->
-    <div class="flex pl-4 sm:overflow-y-scroll bg-postFocusBG">
+    <div class="flex px-4 sm:overflow-y-scroll bg-postFocusBG">
         <div class="flex flex-col w-full text-xl text-primary">
             <!-- <div class="w-auto">No Replies</div> -->
             <div v-if="!isChangingThreadContext" class="flex flex-col bg-orange-400s preload-gutter divide-y border-slate-600 divide-inherit text-sm">

--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,7 @@
         --color-feedcolumn-settings-btn-selected:theme(colors.slate.800);
         --color-feedcolumn-settings-btn-selected-hover:theme(colors.slate.600);
         --color-userfocusmodal-banner-bg:theme(colors.slate.400);
+        --color-postfocusmodal-details-shadow:theme(colors.slate.800);
     }
 }
 
@@ -121,4 +122,5 @@
     --color-feedcolumn-settings-btn-selected:theme(colors.blue.300);
     --color-feedcolumn-settings-btn-selected-hover:theme(colors.blue.200);
     --color-userfocusmodal-banner-bg:theme(colors.slate.600);
+    --color-postfocusmodal-details-shadow:theme(colors.black);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -61,6 +61,7 @@ export default {
         feedColumnSettingsBtnSelected: "oklch(from var(--color-feedcolumn-settings-btn-selected) l c h / <alpha-value>)",
         feedColumnSettingsBtnSelectedHover: "oklch(from var(--color-feedcolumn-settings-btn-selected-hover) l c h / <alpha-value>)",
         userFocusModalBannerBG: "oklch(from var(--color-userfocusmodal-banner-bg) l c h / <alpha-value>)",
+        postFocusModalDetailsShadow: "oklch(from var(--color-postfocusmodal-details-shadow) l c h / <alpha-value>)",
       },
       fontSize:{
         feedPostName: '0.75rem',


### PR DESCRIPTION
- Updates `PostFocusModal` so that controls ("scroll to top", "view image" and "close) are visible even when scrolling when using the application on small-width screens.
- Also fixes issue where the `RichPostTextBsky` used for the main Post text in `PostFocusModal` would not update when traveling back up the navigation history.