### PR TITLE
Feature #188 - Add options to hide post metrics

### DIFF
--- a/src/components/Post/PostInteractionIcons.vue
+++ b/src/components/Post/PostInteractionIcons.vue
@@ -5,14 +5,14 @@
         :class="canUserReply ? 'group cursor-pointer hover:bg-btnSubtle' : 'text-disabled select-none'"
         @click="canUserReply && replyToPost()" :title="postDetails.whoCanReply(postData)">
             <i-solar:chat-dots-outline class="pointer-events-none group-hover:text-yellow-600"/>
-            <div class="pl-1" :title="postData.replyCount?.toString()">{{ getCompactNumberValue(postData.replyCount ? postData.replyCount : 0) }}</div>
+            <div v-if="!AppSettingsState.Settings.isHidingComments" class="pl-1" :title="postData.replyCount?.toString()">{{ getCompactNumberValue(postData.replyCount ? postData.replyCount : 0) }}</div>
         </div>
         <div class="group flex rounded-full items-center cursor-pointer gap-1 hover:bg-btnSubtle"
         title="Repost"
         @click="showRepostOptionsMenu($event, postData)">
             <i-mingcute:repeat-line
             :class="[isPostRepostedByUser ? 'text-blue-500' : 'group-hover:text-blue-500']"/>
-            <div v-if="!isAwaitingRepostUpdate" :title="postData.repostCount?.toString()">{{ getCompactNumberValue(postData.repostCount ? postData.repostCount : 0) }}</div>
+            <div v-if="!isAwaitingRepostUpdate" :title="postData.repostCount?.toString()" :class="[{'hidden' : AppSettingsState.Settings.isHidingShares}]">{{ getCompactNumberValue(postData.repostCount ? postData.repostCount : 0) }}</div>
             <i-mingcute:loading-fill v-else class="text-primary spinner self-center size-3"/>
         </div>
         <div @click="toggleLike" class="group flex rounded-full items-center cursor-pointer
@@ -20,7 +20,9 @@
         title="Like Post">
             <i-mingcute:heart-fill
             :class="[isPostLikedByUser ? 'text-red-500' : 'group-hover:text-red-500']"/>
-            <div v-if="!isAwaitingLikeUpdate":title="postData.likeCount?.toString()">{{ getCompactNumberValue(postData.likeCount ? postData.likeCount : 0) }}</div>
+            <div v-if="!isAwaitingLikeUpdate":title="postData.likeCount?.toString()" :class="[{'hidden' : AppSettingsState.Settings.isHidingLikes}]">
+                {{ getCompactNumberValue(postData.likeCount ? postData.likeCount : 0) }}
+            </div>
             <i-mingcute:loading-fill v-else class="text-primary spinner self-center size-3"/>
         </div>
         <!-- <div v-if="!noShareButton" class="group flex items-center cursor-pointer hover:text-slate-300"
@@ -56,6 +58,7 @@ import MingcuteRepeatLine from '~icons/mingcute/repeat-line';
 import MingcuteQuoteRightFill from '~icons/mingcute/quote-right-fill';
 import MingcuteDelete2Line from '~icons/mingcute/delete-2-line';
 import { AppBskyFeedThreadgate } from '@atproto/api';
+import { AppSettingsState } from '../../state/AppSettingsState.vue';
 
 function CopyPostLink(postUri:string, handle:string=""){
     let link = CreateBskyWeblink(postUri, handle);
@@ -111,6 +114,7 @@ export default defineComponent({
     data(){
         return{
             AppState,
+            AppSettingsState,
             isPostMenuVisible: false,
             postDetails,
             getCompactNumberValue,

--- a/src/components/Settings/SettingsPanel.vue
+++ b/src/components/Settings/SettingsPanel.vue
@@ -31,6 +31,9 @@
                                         <CheckBox :model-value="AppSettingsState.Settings.isDarkMode" @value-toggled="toggleTheme">
                                             Dark Mode?
                                         </CheckBox>
+                                        <CheckBox :model-value="AppSettingsState.Settings.isHidingMetrics" @value-toggled="toggleMetrics">
+                                            Hide Metrics?
+                                        </CheckBox>
                                         <SquareButton :is-disabled="AppSettingsState.Settings.isShowingIntroMessage"
                                         class="self-start bg-btn hover:bg-btnHover"
                                         title="Display Introductory Tutorial/Instructions"
@@ -192,7 +195,9 @@ export default defineComponent({
                     General:{
                         name:'General',
                         data:{
-                            isDarkMode:AppState.isDarkMode
+                            isDarkMode:AppState.isDarkMode,
+                            /**Should details like Follower count, Post Likes count be hidden? */
+                            isHidingMetics:AppSettingsState.Settings.isHidingMetrics
                         },
                         /**Indicates if the option should only be available in Dev mode. */
                         devOnly:false,
@@ -262,6 +267,9 @@ export default defineComponent({
         },
         toggleTheme(){
             AppSettingsState.Settings.isDarkMode = !AppSettingsState.Settings.isDarkMode;
+        },
+        toggleMetrics(){
+            AppSettingsState.Settings.isHidingMetrics = !AppSettingsState.Settings.isHidingMetrics;
         },
         /**Switch the currently viewed settings category. */
         switchCategory(category:string|undefined){

--- a/src/components/Settings/SettingsPanel.vue
+++ b/src/components/Settings/SettingsPanel.vue
@@ -15,7 +15,7 @@
             </div>
             <div class="flex flex-col sm:flex-row grow overflow-hidden">
                 <div class="flex sm:flex-col text-nowrap overflow-x-auto gap-1 bg-postBG text-primary p-2 drop-shadow min-w-36">
-                    <template v-for="(category, index) in SetttingData.Options">
+                    <template v-for="(category, index) in SettingData.Options">
                         <SettingsCategory v-if="!category.devOnly || isInDevEnvironment == category.devOnly" :index="index"
                         :selected="index == selectedCategoryIndex" @category-clicked="switchCategory">
                             {{ category.name }}
@@ -26,16 +26,39 @@
                     <div class="relative p-2 rounded border border-outline w-full h-full overflow-hidden">
                         <div class="relative w-full h-full overflow-hidden">
                             <TransitionGroup>
-                                <div v-if="selectedCategoryIndex == Object.keys(SetttingData.Options)[0]">
-                                    <div class="flex flex-col gap-1">
+                                <div v-if="selectedCategoryIndex == Object.keys(SettingData.Options)[0]" class="h-full">
+                                    <div class="flex flex-col gap-1 h-full">
+                                        <div class="text-xl font-medium">Appearance</div>
                                         <CheckBox :model-value="AppSettingsState.Settings.isDarkMode" @value-toggled="toggleTheme">
                                             Dark Mode?
                                         </CheckBox>
-                                        <CheckBox :model-value="AppSettingsState.Settings.isHidingMetrics" @value-toggled="toggleMetrics">
-                                            Hide Metrics?
-                                        </CheckBox>
+                                        <div class="text-xs">Toggle between Light and Dark application theme colors.</div>
+                                        <div class="text-xl font-medium">Hide Metrics</div>
+                                        <div class="text-xs">Hide Post Metrics (comments, shares, likes) and User Metrics (followers, following).</div>
+                                        <div class="flex gap-1 flex-wrap">
+                                            <CheckBox title="Hide Comment Count on Posts" :model-value="AppSettingsState.Settings.isHidingComments"
+                                            @value-toggled="togglePostCommentsCount">
+                                                Hide Comments
+                                            </CheckBox>
+                                            <CheckBox title="Hide Share Count on Posts" :model-value="AppSettingsState.Settings.isHidingShares"
+                                            @value-toggled="togglePostSharesCount">
+                                                Hide Shares
+                                            </CheckBox>
+                                            <CheckBox title="Hide Likes Count on Posts" :model-value="AppSettingsState.Settings.isHidingLikes"
+                                            @value-toggled="togglePostLikesCount">
+                                                Hide Likes
+                                            </CheckBox>
+                                            <CheckBox title="Hide Following Count on User Pages" :model-value="AppSettingsState.Settings.isHidingFollowing"
+                                            @value-toggled="toggleUserFollowingCount">
+                                                Hide Following
+                                            </CheckBox>
+                                            <CheckBox title="Hide Follower Count on User Pages" :model-value="AppSettingsState.Settings.isHidingFollowers"
+                                            @value-toggled="toggleUserFollowersCount">
+                                                Hide Followers
+                                            </CheckBox>
+                                        </div>
                                         <SquareButton :is-disabled="AppSettingsState.Settings.isShowingIntroMessage"
-                                        class="self-start bg-btn hover:bg-btnHover"
+                                        class="self-start bg-btn hover:bg-btnHover mt-1"
                                         title="Display Introductory Tutorial/Instructions"
                                         @click="AppSettingsState.Settings.isShowingIntroMessage = true">
                                             Show Intro Instructions
@@ -47,7 +70,7 @@
                                         </SquareButton>
                                     </div>
                                 </div>
-                                <div v-if="selectedCategoryIndex == Object.keys(SetttingData.Options)[1]"
+                                <div v-if="selectedCategoryIndex == Object.keys(SettingData.Options)[1]"
                                 class="relative flex flex-col gap-2 w-full h-full overflow-auto">
                                     <div class="font-thin text-2xl">Language Selection</div>
                                     <CheckBox :model-value="AppSettingsState.Settings.isAcceptingAllLanguages" @value-toggled="toggleAcceptAllLanguages">
@@ -94,10 +117,10 @@
                                     </div>
                                     <!-- <InLaInput text-label="Tag Blacklist" :model-value="SetttingData.Options.PostFilters.data.tagBlacklist"/> -->
                                 </div>
-                                <div v-if="isInDevEnvironment && selectedCategoryIndex == Object.keys(SetttingData.Options)[2]">
+                                <div v-if="isInDevEnvironment && selectedCategoryIndex == Object.keys(SettingData.Options)[2]">
                                     <div class="italic">Account Settings are still not supported. Check back later!</div>
                                 </div>
-                                <div v-if="isInDevEnvironment && selectedCategoryIndex == Object.keys(SetttingData.Options)[3]"
+                                <div v-if="isInDevEnvironment && selectedCategoryIndex == Object.keys(SettingData.Options)[3]"
                                 class="relative flex flex-col w-full h-full overflow-y-auto pr-2">
                                     <div class="italic">Devloper testing commands - Be careful!</div>
                                     <div v-if="!isTauri()" class="flex flex-col gap-1 border border-outline rounded p-2">
@@ -110,22 +133,22 @@
                                         </SquareButton>
                                         <div v-if="isSavedFeedsLoaded" class="text-sm">
                                             <div>
-                                                {{ `There is/are ${SetttingData.Options.Developer.data.recordsFromDB.length}
+                                                {{ `There is/are ${SettingData.Options.Developer.data.recordsFromDB.length}
                                                 SavedFeed record(s) stored via IndexedDB.` }}
                                             </div>
-                                            <div>{{ `There is/are ${SetttingData.Options.Developer.data.savedFeeds.length}
+                                            <div>{{ `There is/are ${SettingData.Options.Developer.data.savedFeeds.length}
                                                 Feed(s) saved.` }}</div>
                                         </div>
                                         <div v-if="isSavedFeedsLoaded" class="flex flex-col rounded border border-outline
                                         p-1 overflow-auto">
                                             <table class="text-sm whitespace-nowrap border-separate">
                                                 <thead>
-                                                    <th v-for="col in Object.keys(SetttingData.Options.Developer.data.savedFeeds[0])">
+                                                    <th v-for="col in Object.keys(SettingData.Options.Developer.data.savedFeeds[0])">
                                                         {{ col }}
                                                     </th>
                                                 </thead>
                                                 <tbody>
-                                                    <tr v-for="(feed, index) in SetttingData.Options.Developer.data.savedFeeds"
+                                                    <tr v-for="(feed, index) in SettingData.Options.Developer.data.savedFeeds"
                                                     class="bg-btn border">
                                                         <td v-for="(col, colIndex) in Object.keys(feed)" class="borders text-center px-1"
                                                         :class="{'rounded-tl' : index == 0 && colIndex == 0, 'rounded-tr' : index == 0 && colIndex == 6}">
@@ -190,14 +213,19 @@ export default defineComponent({
             LocalesObject,
             stringToJSON,
             isTauri,
-            SetttingData: {
+            SettingData: {
                 Options:{
                     General:{
                         name:'General',
                         data:{
                             isDarkMode:AppState.isDarkMode,
                             /**Should details like Follower count, Post Likes count be hidden? */
-                            isHidingMetics:AppSettingsState.Settings.isHidingMetrics
+                            isHidingMetics:AppSettingsState.Settings.isHidingMetrics,
+                            isHidingComments: AppSettingsState.Settings.isHidingComments,
+                            isHidingShares: AppSettingsState.Settings.isHidingShares,
+                            isHidingLikes: AppSettingsState.Settings.isHidingLikes,
+                            isHidingFollowers: AppSettingsState.Settings.isHidingFollowers,
+                            isHidingFollowing: AppSettingsState.Settings.isHidingFollowing
                         },
                         /**Indicates if the option should only be available in Dev mode. */
                         devOnly:false,
@@ -271,6 +299,21 @@ export default defineComponent({
         toggleMetrics(){
             AppSettingsState.Settings.isHidingMetrics = !AppSettingsState.Settings.isHidingMetrics;
         },
+        togglePostCommentsCount(){
+            AppSettingsState.Settings.isHidingComments = !AppSettingsState.Settings.isHidingComments;
+        },
+        togglePostSharesCount(){
+            AppSettingsState.Settings.isHidingShares = !AppSettingsState.Settings.isHidingShares;
+        },
+        togglePostLikesCount(){
+            AppSettingsState.Settings.isHidingLikes = !AppSettingsState.Settings.isHidingLikes;
+        },
+        toggleUserFollowingCount(){
+            AppSettingsState.Settings.isHidingFollowing = !AppSettingsState.Settings.isHidingFollowing;
+        },
+        toggleUserFollowersCount(){
+            AppSettingsState.Settings.isHidingFollowers = !AppSettingsState.Settings.isHidingFollowers;
+        },
         /**Switch the currently viewed settings category. */
         switchCategory(category:string|undefined){
             if(category) this.selectedCategoryIndex = category;
@@ -317,11 +360,11 @@ export default defineComponent({
             .then(res => {
                 console.log(res);
                 let feedResult = res as SavedFeeds[];
-                this.SetttingData.Options.Developer.data.hasIndexedDBDataBeenRequested = true;
+                this.SettingData.Options.Developer.data.hasIndexedDBDataBeenRequested = true;
                 if(feedResult && feedResult.length>0){
                     let loadedFeeds:IFeedDBData[]|undefined = stringToJSON(feedResult[0].data);
-                    this.SetttingData.Options.Developer.data.savedFeeds = loadedFeeds;
-                    this.SetttingData.Options.Developer.data.recordsFromDB = feedResult;
+                    this.SettingData.Options.Developer.data.savedFeeds = loadedFeeds;
+                    this.SettingData.Options.Developer.data.recordsFromDB = feedResult;
                 }
             })
             .catch(err => {
@@ -341,9 +384,9 @@ export default defineComponent({
          */
         clearSavedFeeds(){
             DeleteIndexedDBSavedFeeds();
-            this.SetttingData.Options.Developer.data.savedFeeds = [];
-            this.SetttingData.Options.Developer.data.recordsFromDB = [];
-            this.SetttingData.Options.Developer.data.hasIndexedDBDataBeenRequested = false;
+            this.SettingData.Options.Developer.data.savedFeeds = [];
+            this.SettingData.Options.Developer.data.recordsFromDB = [];
+            this.SettingData.Options.Developer.data.hasIndexedDBDataBeenRequested = false;
         }
     },
     computed:{
@@ -352,7 +395,7 @@ export default defineComponent({
             return false;
         },
         isSavedFeedsLoaded(){
-            if(this.SetttingData.Options.Developer.data.savedFeeds.length>0) return true;
+            if(this.SettingData.Options.Developer.data.savedFeeds.length>0) return true;
             return false;
         },
         /**
@@ -360,8 +403,8 @@ export default defineComponent({
          * been attempted and no records were found.
          */
         noReturnedFeeds(){
-            if(this.SetttingData.Options.Developer.data.hasIndexedDBDataBeenRequested &&
-                this.SetttingData.Options.Developer.data.savedFeeds.length<1) return true;
+            if(this.SettingData.Options.Developer.data.hasIndexedDBDataBeenRequested &&
+                this.SettingData.Options.Developer.data.savedFeeds.length<1) return true;
             return false;
         }
     },

--- a/src/components/User/UserFocusModal.vue
+++ b/src/components/User/UserFocusModal.vue
@@ -111,11 +111,11 @@
                                     </div>
                                 </div>
                                 <div class="flex mt-2">
-                                    <div class="flex text-sm pr-2">
+                                    <div v-if="!AppSettingsState.Settings.isHidingFollowers" class="flex text-sm pr-2">
                                         <div class="font-bold pr-1">{{UserFocusModalState.GetCurrentHistoryData() ? UserFocusModalState.GetCurrentHistoryData().ProfileData.followersCount : '1'}}</div>
                                         <div class="text-secondary">followers</div>
                                     </div>
-                                    <div class="flex text-sm pr-2">
+                                    <div v-if="!AppSettingsState.Settings.isHidingFollowing" class="flex text-sm pr-2">
                                         <div class="font-bold pr-1">{{UserFocusModalState.GetCurrentHistoryData() ? UserFocusModalState.GetCurrentHistoryData().ProfileData.followsCount : '33'}}</div>
                                         <div class="text-secondary">following</div>
                                     </div>
@@ -327,6 +327,7 @@ import { getAuthorFeed, getAuthorLikes, getAuthorPostsOnly, getAuthorRepliesOnly
 import SquareButton from '../Utilities/SquareButton.vue';
 import { OptionsMenuState } from '../../state/OptionsMenuState.vue';
 import { IOptionMenuItem } from '../Utilities/OptionsMenu.vue';
+import { AppSettingsState } from '../../state/AppSettingsState.vue';
 
 /**
  * Used to create a HTTP URL link To the currently view User's profile.
@@ -341,6 +342,7 @@ export default defineComponent({
     data(){
         return{
             AppState,
+            AppSettingsState,
             UserFocusModalState,
             MediaType,
             isImage,

--- a/src/components/Utilities/CheckBox.vue
+++ b/src/components/Utilities/CheckBox.vue
@@ -26,7 +26,7 @@ export default defineComponent({
     },
     emits:{
         valueToggled:(value:boolean) => {
-            return value;
+            if(typeof value == 'boolean') return true;
         },
     },
     methods:{

--- a/src/interfaces/SettingsInterfaces.ts
+++ b/src/interfaces/SettingsInterfaces.ts
@@ -17,6 +17,7 @@ export class AppSettingsClass {
     isBlacklist = false;
     selectedLanguages = [] as LangCode[];
     isShowingIntroMessage = true;
+    isHidingMetrics = false;
 }
 export interface IAppSettings extends AppSettingsClass{}
 type AppSettingsPropsArray = Array<keyof IAppSettings>;

--- a/src/interfaces/SettingsInterfaces.ts
+++ b/src/interfaces/SettingsInterfaces.ts
@@ -17,7 +17,11 @@ export class AppSettingsClass {
     isBlacklist = false;
     selectedLanguages = [] as LangCode[];
     isShowingIntroMessage = true;
-    isHidingMetrics = false;
+    isHidingComments = false;
+    isHidingShares = false;
+    isHidingLikes = false;
+    isHidingFollowers = false;
+    isHidingFollowing = false;
 }
 export interface IAppSettings extends AppSettingsClass{}
 type AppSettingsPropsArray = Array<keyof IAppSettings>;

--- a/src/lib/db/web_db.ts
+++ b/src/lib/db/web_db.ts
@@ -18,7 +18,11 @@ interface AppSettings{ //extends IAppSettings{
   isBlacklist: boolean;
   selectedLanguages: string //have to convert from LangCode[] to string
   isShowingIntroMessage: boolean;
-  isHidingMetrics: boolean;
+  isHidingComments: boolean;
+  isHidingShares: boolean;
+  isHidingLikes: boolean;
+  isHidingFollowers: boolean;
+  isHidingFollowing: boolean;
 }
 
 /**IndexedDB database with `savedFeeds` store/table.*/

--- a/src/lib/db/web_db.ts
+++ b/src/lib/db/web_db.ts
@@ -1,10 +1,15 @@
 import Dexie, {type EntityTable} from 'dexie';
+import { IAppSettings } from '../../interfaces/SettingsInterfaces';
 
 interface Feed{
     id: number;
     data: string;
 }
 
+/**
+ * Based on {@link IAppSettings}. Currently does not extend because
+ * of a "LangCode[] to string" conversion issue.
+ */
 interface AppSettings{ //extends IAppSettings{
   id: number;
   isDarkMode: boolean;
@@ -13,6 +18,7 @@ interface AppSettings{ //extends IAppSettings{
   isBlacklist: boolean;
   selectedLanguages: string //have to convert from LangCode[] to string
   isShowingIntroMessage: boolean;
+  isHidingMetrics: boolean;
 }
 
 /**IndexedDB database with `savedFeeds` store/table.*/

--- a/src/state/AppSettingsState.vue
+++ b/src/state/AppSettingsState.vue
@@ -29,8 +29,11 @@ export const AppSettingsState = reactive({
         isBlacklist: false,
         selectedLanguages:[] as LangCode[],
         isShowingIntroMessage: true,
-        /**Should details like Follower count, Post Likes count be hidden? */
-        isHidingMetrics:false,
+        isHidingComments: false,
+        isHidingShares: false,
+        isHidingLikes: false,
+        isHidingFollowers: false,
+        isHidingFollowing: false,
     } as IAppSettings,
     AppStore:Store,
     /**
@@ -158,7 +161,11 @@ export const AppSettingsState = reactive({
                 appSettings.isWhitelist = loadedSettings.isWhitelist;
                 appSettings.selectedLanguages = JSON.parse(loadedSettings.selectedLanguages);
                 appSettings.isShowingIntroMessage = loadedSettings.isShowingIntroMessage;
-                appSettings.isHidingMetrics = loadedSettings.isHidingMetrics;
+                appSettings.isHidingComments = loadedSettings.isHidingComments;
+                appSettings.isHidingShares = loadedSettings.isHidingShares;
+                appSettings.isHidingLikes = loadedSettings.isHidingLikes;
+                appSettings.isHidingFollowers = loadedSettings.isHidingFollowers;
+                appSettings.isHidingFollowing = loadedSettings.isHidingFollowing;
             })
             .catch(err => {
                 console.log(err);
@@ -196,7 +203,11 @@ export const AppSettingsState = reactive({
                 isWhitelist:cs.isWhitelist,
                 selectedLanguages:JSON.stringify(cs.selectedLanguages),
                 isShowingIntroMessage:cs.isShowingIntroMessage,
-                isHidingMetrics:cs.isHidingMetrics,
+                isHidingComments: cs.isHidingComments,
+                isHidingShares: cs.isHidingShares,
+                isHidingLikes: cs.isHidingLikes,
+                isHidingFollowers: cs.isHidingFollowers,
+                isHidingFollowing: cs.isHidingFollowing,
             })
             // .then(res => {
             //     console.log(res);

--- a/src/state/AppSettingsState.vue
+++ b/src/state/AppSettingsState.vue
@@ -19,6 +19,9 @@ export const AppSettingsState = reactive({
     ///only show certain elements if the required variable value has
     ///been loaded.
     isSettingsLoaded:false,
+    /**
+     * Based on {@link IAppSettings} derived from AppSettingsClass.
+     */
     Settings:{
         isDarkMode:false,
         isAcceptingAllLanguages: true,
@@ -26,6 +29,8 @@ export const AppSettingsState = reactive({
         isBlacklist: false,
         selectedLanguages:[] as LangCode[],
         isShowingIntroMessage: true,
+        /**Should details like Follower count, Post Likes count be hidden? */
+        isHidingMetrics:false,
     } as IAppSettings,
     AppStore:Store,
     /**
@@ -153,6 +158,7 @@ export const AppSettingsState = reactive({
                 appSettings.isWhitelist = loadedSettings.isWhitelist;
                 appSettings.selectedLanguages = JSON.parse(loadedSettings.selectedLanguages);
                 appSettings.isShowingIntroMessage = loadedSettings.isShowingIntroMessage;
+                appSettings.isHidingMetrics = loadedSettings.isHidingMetrics;
             })
             .catch(err => {
                 console.log(err);
@@ -190,6 +196,7 @@ export const AppSettingsState = reactive({
                 isWhitelist:cs.isWhitelist,
                 selectedLanguages:JSON.stringify(cs.selectedLanguages),
                 isShowingIntroMessage:cs.isShowingIntroMessage,
+                isHidingMetrics:cs.isHidingMetrics,
             })
             // .then(res => {
             //     console.log(res);


### PR DESCRIPTION
Adds ability for User to hide various metrics:

- **Posts**: Comment, Shares and Likes count
- **User Pages**: follower and following count