### PR TITLE
Hotfix #149 - `AvatarRound` User feed creation error + extras

### DIFF
--- a/src/components/Feed/FeedEditModal.vue
+++ b/src/components/Feed/FeedEditModal.vue
@@ -167,7 +167,7 @@ import InLaInput from '../Utilities/InLaInput.vue';
 import SquareButton from '../Utilities/SquareButton.vue';
 import UserSearchBar from '../Utilities/UserSearchBar.vue';
 import { AppState, toast, TrapFocus } from '../../state/AppState.vue';
-import { AddFeedToList, FeedState, GenerateUniqueId, GetFeed, GetFeedDataForFeedType, UpdateFeedDetails } from '../../state/FeedList.vue';
+import { AddFeedToList, defaultNumOfPostsToLoad, FeedState, GenerateUniqueId, GetFeed, GetFeedDataForFeedType, UpdateFeedDetails } from '../../state/FeedList.vue';
 import { HandleAPIError } from '../../helpers/errors.ts';
 import { IFeedColumnSettings, IFeedDescription, IFeedReturnedPostResults } from '../../interfaces/FeedInterfaces.ts';
 import { ProfileView, ProfileViewDetailed } from '@atproto/api/dist/client/types/app/bsky/actor/defs';
@@ -360,7 +360,7 @@ export default defineComponent({
             var feedResult:IFeedReturnedPostResults = {data:[], cursor:''};
 
             //Perform required API call
-            await GetFeedDataForFeedType(this.selectedFeedType as FeedEnums.Types,this.feedFilters.user.did,this.feedFilters.tag)//(<any>FeedEnums.Types)[this.selectedFeedType]
+            await GetFeedDataForFeedType(this.selectedFeedType as FeedEnums.Types,this.feedFilters.user.did,this.feedFilters.tag,'',defaultNumOfPostsToLoad)//(<any>FeedEnums.Types)[this.selectedFeedType]
             .then(res => feedResult = res)
             .catch(err => {
                 console.log(err);

--- a/src/components/Feed/FeedEditModal.vue
+++ b/src/components/Feed/FeedEditModal.vue
@@ -167,9 +167,7 @@ import InLaInput from '../Utilities/InLaInput.vue';
 import SquareButton from '../Utilities/SquareButton.vue';
 import UserSearchBar from '../Utilities/UserSearchBar.vue';
 import { AppState, toast, TrapFocus } from '../../state/AppState.vue';
-import { AddFeedToList, defaultNumOfPostsToLoad, FeedState, GenerateUniqueId, GetFeed, GetFeedDataForFeedType, UpdateFeedDetails } from '../../state/FeedList.vue';
-import { HandleAPIError } from '../../helpers/errors.ts';
-import { IFeedColumnSettings, IFeedDescription, IFeedReturnedPostResults } from '../../interfaces/FeedInterfaces.ts';
+import { AddFeedToList, FeedState, GetFeed, PrepareFeedData, UpdateFeedDetails } from '../../state/FeedList.vue';
 import { ProfileView, ProfileViewDetailed } from '@atproto/api/dist/client/types/app/bsky/actor/defs';
 import CheckBox from '../Utilities/CheckBox.vue';
 import { GetBrowsingAgent } from '../../lib/api.vue';
@@ -352,89 +350,34 @@ export default defineComponent({
         /**
          * Method that adds a new feed with specified options
          * to the App's `FeedList`.
-         * This should probably be in `FeedList`.
          */
         async createFeed(){
             this.attemptingToCreateFeed = true;
-            /**The object that will be added to the FeedList. */
-            var feedResult:IFeedReturnedPostResults = {data:[], cursor:''};
 
-            //Perform required API call
-            await GetFeedDataForFeedType(this.selectedFeedType as FeedEnums.Types,this.feedFilters.user.did,this.feedFilters.tag,'',defaultNumOfPostsToLoad)//(<any>FeedEnums.Types)[this.selectedFeedType]
-            .then(res => feedResult = res)
+            PrepareFeedData(this.selectedFeedType as FeedEnums.Types,
+            {
+                did:this.feedFilters.user.did,
+                handle:this.feedFilters.user.handle,
+                name:''
+            },
+            this.feedFilters.tag)
+            .then(res => {
+                //Create the Feed
+                if(AppState.isCreatingFeed){
+                    AddFeedToList(res.description,res.data,res.cursor,res.seenAt,false);
+                    this.closeModal();
+                }
+                else if(AppState.isUpdatingFeed){
+                    UpdateFeedDetails(FeedState.selectedFeed,res.description,res.data,res.cursor);
+                    this.closeModal();
+                }
+            })
             .catch(err => {
-                console.log(err);
-                toast.add(HandleAPIError(err, 'Error getting data for creating feed'))
+                toast.add({summary:'Error', detail:`${err}`, severity:'error', group:'tr', life:3000});
+                setTimeout(() => {
+                    this.attemptingToCreateFeed = false;
+                }, 800);
             });
-            console.log(feedResult);//DEBUG
-            var defaultAppearance:IFeedColumnSettings = {
-                width: FeedEnums.Widths.Small,
-            }
-
-            var usedFeedId:string = '';
-            if(AppState.isCreatingFeed) usedFeedId = GenerateUniqueId(10);
-            else if(AppState.isUpdatingFeed) usedFeedId = FeedState.selectedFeed;
-            //FIX: NEED TO GET REAL CURRENT USER ID FROM APP STATE EVENTUALLY
-            /**Starting template for IFeedDescription used to create Feed. */
-            var desc:IFeedDescription = {
-                feedId: usedFeedId,
-                userId:1,
-                feedHandle:'loading_tag',
-                feedType:FeedEnums.Types.User,
-                feedIcon:FeedEnums.Icons.Art,
-                newPosts:0,totalPosts:30,
-                feedColumnSettings:defaultAppearance,
-                feedSourceDID:'',
-                feedTags:''
-            }
-            let concatTags = this.validTags.join(',');
-            //Select correct returned Object value based on Feed Type
-            switch (this.selectedFeedType) {
-                case FeedEnums.Types.User:
-                    //Generate Feed Description based on selected options
-                    desc = {...desc,
-                        feedHandle:this.feedFilters.user.handle,
-                        feedName:this.feedFilters.user.displayName ? this.feedFilters.user.displayName : '',
-                        feedSourceDID:this.feedFilters.user.did
-                    }
-                    break;
-                case FeedEnums.Types.Tag:
-                    //Generate Feed Description based on selected options
-                    desc = {...desc,
-                        feedType:FeedEnums.Types.Tag,
-                        feedIcon:FeedEnums.Icons.Hashtag,
-                        feedHandle:'hashtag',
-                        feedName:concatTags,
-                        feedTags:concatTags
-                    }
-                    break;
-                case FeedEnums.Types.Notifications:
-                    desc = {...desc,
-                        feedType:FeedEnums.Types.Notifications,
-                        feedIcon:FeedEnums.Icons.Notifications,
-                        feedHandle:'notifs',
-                        feedName:'Notifications'
-                    }
-                    break;
-                case FeedEnums.Types.Trending:
-                    desc = {...desc,
-                        feedType:FeedEnums.Types.Trending,
-                        feedIcon:FeedEnums.Icons.Trending,
-                        feedHandle:'trending',
-                        feedName:'Trending'
-                    }
-                    break;
-                default:
-                    break;
-            }
-            //Create the Feed
-            if(AppState.isCreatingFeed){
-                AddFeedToList(desc,feedResult.data, feedResult.cursor, feedResult.seenAt, false);
-            }
-            else if(AppState.isUpdatingFeed){
-                UpdateFeedDetails(FeedState.selectedFeed,desc,feedResult.data,feedResult.cursor);
-            }
-            this.closeModal();
         },
         closeModal(){
             // AppState.ToggleCreateFeedModal();

--- a/src/components/Utilities/Userlink.vue
+++ b/src/components/Utilities/Userlink.vue
@@ -13,6 +13,7 @@
 import { defineComponent } from 'vue'
 import { AddFeedToList, PrepareFeedData } from '../../state/FeedList.vue';
 import { FeedEnums } from '../../enums/FeedEnums';
+import { toast } from '../../state/AppState.vue';
 
 export default defineComponent({
     props:{
@@ -28,9 +29,11 @@ export default defineComponent({
                 did:'',
                 handle:this.userlinkValue ? this.userlinkValue.slice(1) : '' ,
                 name:''
-            },
-            undefined)
-            .then(res => AddFeedToList(res.description,res.data,res.cursor,res.seenAt,false));
+            })
+            .then(res => AddFeedToList(res.description,res.data,res.cursor,res.seenAt,false))
+            .catch(err => {
+                toast.add({summary:'Error', detail:`${err}`, severity:'error', group:'tr', life:3000});
+            });
         }
     }
 })

--- a/src/state/FeedList.vue
+++ b/src/state/FeedList.vue
@@ -113,6 +113,11 @@ export async function AddFeedToList(description:IFeedDescription, feed:FeedViewP
 export async function PrepareFeedData(feedType:FeedEnums.Types,userData:IUserSearchResult={did:'',name:'',handle:''},tags:string=''):Promise<IFeedListing>{
     /**Object that will hold the returned Feed data. */
     var feedResult:IFeedReturnedPostResults = {data:[], cursor:''};
+    if(userData.did.trim() == '' && userData.handle.trim() != ''){
+        //get DID associated with handle
+        await GetBrowsingAgent().getProfile({actor: userData.handle})
+        .then(res => userData.did = res.data.did);
+    }
     await GetFeedDataForFeedType(feedType,userData.did,tags,'',defaultNumOfPostsToLoad)
     .then(res => {
         feedResult = res;

--- a/src/state/FeedList.vue
+++ b/src/state/FeedList.vue
@@ -153,7 +153,6 @@ export async function PrepareFeedData(feedType:FeedEnums.Types,userData:IUserSea
         desc = res;
     })
 
-    AppState.isCreatingFeed = false;
     return {description:desc, data:feedResult.data, cursor:feedResult.cursor, isAwaitingFeedData:false};
 }
 
@@ -565,7 +564,7 @@ export async function GetFeedDataForFeedType(feedType:FeedEnums.Types,did:string
             });
             break;
         case FeedEnums.Types.Tag:
-            await getTagPosts(tags,cursor,postsToGet)
+            await getTagPosts(tags,cursor,25)
             .then(res => {
                 if(res.data.cursor && res.data.cursor.trim()!='') feedResult.cursor = res.data.cursor;
                 //Place Posts in a "Feed" shaped Object

--- a/src/state/FeedList.vue
+++ b/src/state/FeedList.vue
@@ -41,6 +41,9 @@ const toast = {
     removeAllGroups: () => ToastEventBus.emit('remove-all-groups'),
 };
 
+/**The default value of how many Posts to load when creating/restoring a Feed. */
+export const defaultNumOfPostsToLoad = 10;
+
 export default{
     name:"FeedState"
 }
@@ -110,9 +113,9 @@ export async function AddFeedToList(description:IFeedDescription, feed:FeedViewP
 export async function PrepareFeedData(feedType:FeedEnums.Types,userData:IUserSearchResult={did:'',name:'',handle:''},tags:string=''):Promise<IFeedListing>{
     /**Object that will hold the returned Feed data. */
     var feedResult:IFeedReturnedPostResults = {data:[], cursor:''};
-    await GetFeedDataForFeedType(feedType,userData.did,tags)
+    await GetFeedDataForFeedType(feedType,userData.did,tags,'',defaultNumOfPostsToLoad)
     .then(res => {
-        feedResult.data = res.data;
+        feedResult = res;
     })
     //Check if API call created Error
     // if(IsError(feedResult)){
@@ -518,7 +521,7 @@ export async function LoadFeedPostsAsync(feedDesc:IFeedDescription){
             }
         }
         //Get data for Feed
-        await GetFeedDataForFeedType(feedDesc.feedType,feedDesc.feedSourceDID,feedDesc.feedTags,'',10)
+        await GetFeedDataForFeedType(feedDesc.feedType,feedDesc.feedSourceDID,feedDesc.feedTags,'',defaultNumOfPostsToLoad)
         .then(res => {
             if(feed){
                 console.log(res);//DEBUG


### PR DESCRIPTION
- Fixed issue where Feeds created from AvatarRound context menu could not have older posts loaded.
- Updated FeedEditModal.createFeed() to use the PrepareFeedData() method to create/update a Feed. This should simplify the process of making any adjustments to how Feeds are created going forward now that the process is the same throughout the app (AvatarRound, Userlink, FeedEditModal, etc.).
- Fixed issue where User Feeds could not be created by clicking on a `Userlink` element.