### PR TITLE
Feature #208 - Add build details to `AboutAppModal`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+src/helpers/version.ts

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "version": "0.8.5",
   "type": "module",
   "scripts": {
+    "predev": "node update-version.cjs",
     "dev": "vite --host",
+    "prebuild": "node update-version.ts",
     "build": "vite build",
+    "prebuild-web": "node update-version.cjs",
     "build-web": "vite build --base=/moon/",
     "test": "vitest",
     "preview": "vite preview",
+    "pretauri": "node update-version.cjs",
     "tauri": "tauri",
     "cy:open": "cypress open"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "vite build",
     "prebuild-web": "node update-version.cjs",
     "build-web": "vite build --base=/moon/",
+    "pretest": "node update-version.cjs",
     "test": "vitest",
     "preview": "vite preview",
     "pretauri": "node update-version.cjs",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "predev": "node update-version.cjs",
     "dev": "vite --host",
-    "prebuild": "node update-version.ts",
+    "prebuild": "node update-version.cjs",
     "build": "vite build",
     "prebuild-web": "node update-version.cjs",
     "build-web": "vite build --base=/moon/",

--- a/src/components/Settings/AboutAppModal.vue
+++ b/src/components/Settings/AboutAppModal.vue
@@ -9,7 +9,8 @@
                     <AppLogo :is-button="false" class="h-28 text-white scale-100"/>
                     <div>
                         <div class="text-4xl font-thin">Moongate</div>
-                        <div>Version: {{ getBuildNumber() }}<span class="align-super text-xs">{{isTauri() ? 'Tauri' : 'Web'}}</span></div>
+                        <div>Version: {{ versionDetails.version }}-{{ versionDetails.commitHash }}<span class="align-super text-xs">{{isTauri() ? 'Tauri' : 'Web'}}</span></div>
+                        <div class="italic text-[10px] leading-[10px]">{{ versionDetails.buildDate }}</div>
                     </div>
                 </div>
             </div>
@@ -53,6 +54,7 @@ import { OptionsMenuState } from '../../state/OptionsMenuState.vue';
 import { IOptionMenuItem } from '../Utilities/OptionsMenu.vue';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import AppLogo from '../SVG/AppLogo.vue';
+import { GetVersion, IVersionDetails } from '../../lib/api/VersionService';
 
 /**
  * Method used to open link in the system's default browser.
@@ -75,6 +77,7 @@ export default defineComponent({
     data(){
         return{
             isTauri,
+            versionDetails:{} as IVersionDetails,
             issuesURL: "https://github.com/sondaismith/moongate-issues/",
         }
     },
@@ -103,7 +106,10 @@ export default defineComponent({
             ] as IOptionMenuItem[]
             OptionsMenuState.showOptionMenu(e);
         },
-    }
+    },
+    created() {
+        this.versionDetails = GetVersion();
+    },
 })
 </script>
 

--- a/src/lib/api/VersionService.ts
+++ b/src/lib/api/VersionService.ts
@@ -1,0 +1,17 @@
+import {version,buildDate,commitHash} from "../../helpers/version"
+
+export interface IVersionDetails{
+    version:string,
+    buildDate:string,
+    commitHash:string,
+}
+
+export function GetVersion():IVersionDetails{
+    let inDevEnv = import.meta.env.DEV;
+    let versionText = inDevEnv ? `${version}_dev` : version;
+    return {
+        version:versionText,
+        buildDate,
+        commitHash
+    };
+}

--- a/src/lib/api/VersionService.ts
+++ b/src/lib/api/VersionService.ts
@@ -1,4 +1,4 @@
-import {version,buildDate,commitHash} from "./../../helpers/version.ts"
+import {version,buildDate,commitHash} from "./../../helpers/version"
 
 export interface IVersionDetails{
     version:string,

--- a/src/lib/api/VersionService.ts
+++ b/src/lib/api/VersionService.ts
@@ -1,4 +1,4 @@
-import {version,buildDate,commitHash} from "../../helpers/version"
+import {version,buildDate,commitHash} from "./../../helpers/version"
 
 export interface IVersionDetails{
     version:string,

--- a/src/lib/api/VersionService.ts
+++ b/src/lib/api/VersionService.ts
@@ -1,4 +1,4 @@
-import {version,buildDate,commitHash} from "./../../helpers/version"
+import {version,buildDate,commitHash} from "./../../helpers/version.ts"
 
 export interface IVersionDetails{
     version:string,

--- a/update-version.cjs
+++ b/update-version.cjs
@@ -12,5 +12,4 @@ export const commitHash = '${commitHash}';`;
 
 fs.writeFileSync("./src/helpers/version.ts", content);
 
-console.log(__dirname);
 console.log("Updated application version!", { version, commitHash, buildDate });

--- a/update-version.cjs
+++ b/update-version.cjs
@@ -12,4 +12,5 @@ export const commitHash = '${commitHash}';`;
 
 fs.writeFileSync("./src/helpers/version.ts", content);
 
+console.log(__dirname);
 console.log("Updated application version!", { version, commitHash, buildDate });

--- a/update-version.cjs
+++ b/update-version.cjs
@@ -1,0 +1,15 @@
+//Based on process outlined here: https://dev.to/rensjaspers/how-to-include-version-git-commit-and-build-date-in-your-angular-builds-53ok
+const fs = require("fs");
+const execSync = require("child_process").execSync;
+
+const version = require("./package.json").version;
+const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
+const buildDate = new Date().toUTCString();
+
+const content = `export const version = '${version}';
+export const buildDate = '${buildDate}';
+export const commitHash = '${commitHash}';`;
+
+fs.writeFileSync("./src/helpers/version.ts", content);
+
+console.log("Updated application version!", { version, commitHash, buildDate });


### PR DESCRIPTION
- Added `update-version.cjs` script that will generate build details (version number, commit hash, build date) so that they can be displayed on application's "About App" page. This script is called before the build processes.
- The generated build details are displayed in the application using the new `VersionService.ts` that was also created.