### PR TITLE
Updates option menus + various hotfixes

### DIFF
--- a/src/components/Login/LoginModal.vue
+++ b/src/components/Login/LoginModal.vue
@@ -211,7 +211,7 @@ export default defineComponent({
             /**Indicates whether or not the Login attemot was successful. */
             let loginError = false;
             this.attemptingLogin = true;
-            toast.add({summary:"Test", detail:`Hello ${this.enteredUsername}, attempting to login...`, severity:'info', group:'bc', life:1500});
+            toast.add({summary:"Logging in...", detail:`Hello ${this.enteredUsername}, attempting to login...`, severity:'info', group:'bc', life:1500});
             var handleAddress = `${this.enteredUsername}.${this.defaultHostProvider}`;
             var accountDID = '';
             await LoginBskyAccount(handleAddress, this.enteredPassword)

--- a/src/components/Navbar/FeedButton.vue
+++ b/src/components/Navbar/FeedButton.vue
@@ -241,14 +241,15 @@ export default defineComponent({
                 UpdateSelectedFeed(this.feedDescription.feedId);
                 let menuOptions = [] as IOptionMenuItem[];
                 if(typeof feedSourceDID != "undefined" && feedSourceDID.trim() != '' && this.feedDescription.feedType == FeedEnums.Types.User){
-                    menuOptions.push({Icon:MingcuteProfileFill,Label:'View Profile',Action:function(){ShowUserProfile(feedSourceDID)},Type:ItemType.Option})
+                    menuOptions.push({Icon:MingcuteProfileFill,Label:'View Profile',Action:function(){ShowUserProfile(feedSourceDID)},Type:ItemType.Option});
+                    menuOptions.push({Icon:MingcuteProfileFill,Label:'',Action:()=>{},Type:ItemType.Splitter});
                 }
                 //Need to update "feed edit" functionality, so removing this for now.
                 // if(this.feedDescription.feedType != FeedEnums.Types.FeedGenerator){
                 //     menuOptions.push({Icon:MingcuteEdit4Line,Label:'Edit Feed',Action:function(){UpdateFeed()}})
                 // }
                 menuOptions = [...menuOptions,
-                    {Icon:SolarTrashBinTrashBold,Label:'Remove Feed',Action:function(){DeleteFeed()},Type:ItemType.Option} as IOptionMenuItem,
+                    {Icon:SolarTrashBinTrashBold,Label:'Remove Feed',Action:function(){DeleteFeed()},Type:ItemType.Option,LabelStyle:'text-red-500'} as IOptionMenuItem,
                 ] as IOptionMenuItem[]
                 OptionsMenuState.currentMenuItems = menuOptions;
                 OptionsMenuState.showOptionMenu(e);

--- a/src/components/Navbar/UserButton.vue
+++ b/src/components/Navbar/UserButton.vue
@@ -43,6 +43,7 @@ import { FeedState, RefreshFeed } from '../../state/FeedList.vue';
 
 let optionsMenu:IOptionMenuItem[] = [
     {Icon:MingcuteProfileFill,Label:'View Profile',Action:displayCurrentUsersAccount,Type:ItemType.Option},
+    {Icon:MingcuteProfileFill,Label:'Splitter',Action:()=>{},Type:ItemType.Splitter},
     {Icon:MdiUserSwitch,Label:'Switch User',Action:AppState.ToggleLoginModal,Type:ItemType.Option},
     {Icon:MingcuteExitDoorLine,Label:'Log Out',Action:confirmLogout,Type:ItemType.Option,LabelStyle:'text-red-500'},
 ]

--- a/src/components/User/UserFocusModal.vue
+++ b/src/components/User/UserFocusModal.vue
@@ -64,12 +64,16 @@
                             <div v-else id="userFocusModal-placeholder-banner" class="bg-userFocusModalBannerBG w-full max-h-40s h-40s aspect-[3/1] shrink-0 bg-centers"
                             :style="`mask: url(./assets/placeholder/no_banner_pattern.svg)`">
                             </div>
-                            <div @click="showPFPFullscreen" class="absolute z-[3] flex rounded-full aspect-square size-24 left-4
+                            <div v-if="hasProfileAvatar" @click="showPFPFullscreen" class="absolute z-[3] flex rounded-full aspect-square size-24 left-4
                             items-center justify-center shrink-0 border-2 border-slate-800 bg-no-repeat bg-center bg-cover user-pfp
                             cursor-pointer transition-colors hover:border-hover overflow-hidden">
-                                <img v-if="typeof UserFocusModalState.GetCurrentHistoryData().ProfileData != 'undefined'" :src="UserFocusModalState.GetCurrentHistoryData().ProfileData.avatar"
-                                class="scale-150" :class="{'blur':isAccountBlocked}"/>
-                                <div v-else>PFP</div>
+                                <img :src="UserFocusModalState.GetCurrentHistoryData().ProfileData.avatar"
+                                :class="{'blur scale-150':isAccountBlocked}"/>
+                            </div>
+                            <div v-else class="absolute z-[3] flex rounded-full aspect-square size-24 left-4
+                            items-center justify-center shrink-0 border-2 border-slate-800 bg-no-repeat bg-center bg-cover user-pfp
+                            transition-colors overflow-hidden">
+                                <i-mingcute:butterfly-2-fill class="h-full w-full bg-slate-300 p-2 text-blue-600"/>
                             </div>
                         </div>
                         {{ void "User Details Content" }}
@@ -1002,7 +1006,11 @@ export default defineComponent({
         },
         /**Does this User Profile have a Banner image? */
         hasProfileBanner(){
-            return UserFocusModalState.GetCurrentHistoryData().ProfileData.banner != undefined;
+            return typeof UserFocusModalState.GetCurrentHistoryData().ProfileData.banner != 'undefined';
+        },
+        /**Does this User Profile have am Avatar image? */
+        hasProfileAvatar(){
+            return typeof UserFocusModalState.GetCurrentHistoryData().ProfileData.avatar != 'undefined';
         },
         /**Is the currently displayed account muted by the logged in User? */
         isAccountMuted():boolean{

--- a/src/components/Utilities/ImageContainer.vue
+++ b/src/components/Utilities/ImageContainer.vue
@@ -168,7 +168,10 @@ export default defineComponent({
                 OptionsMenuState.currentMenuItems = [
                     {Icon:MdiImagePlusOutline,Label:'Save Image w/ Author Name',Action:function(){saveImageWithAuthor(image,author,postText)},Type:ItemType.Option},
                 ] as IOptionMenuItem[];
-                if(!isTauri()) OptionsMenuState.currentMenuItems.push({Icon:MdiOpenInNew,Label:'Open Image in New Tab',Action:function(){OpenImageInNewTab(image)},Type:ItemType.Option})
+                if(!isTauri()){
+                    OptionsMenuState.currentMenuItems.push({Icon:MdiOpenInNew,Label:'Splitter',Action:()=>{},Type:ItemType.Splitter});
+                    OptionsMenuState.currentMenuItems.push({Icon:MdiOpenInNew,Label:'Open Image in New Tab',Action:function(){OpenImageInNewTab(image)},Type:ItemType.Option});
+                }
                 OptionsMenuState.showOptionMenu(e);
             // }
         },


### PR DESCRIPTION
- Separated menu options in Options Menu used for `FeedButton`, `UserButton` and `ImageContainer`.
- Updated title used in toast message printed when logging in to account from "Test" to "Logging in...".
- Fixed issue where PFPs on `UserFocusModal` were scaled to 150% when they only should have been when associated account has been blocked.
- Fixed issue where a missing PFP image was not correctly handled in `UserFocusModal`.
- Fixed issue in `UserFocusModal` where the PFP and Banner images could be clicked to display the images fullscreen when there was no image available.