### PR TITLE
Bugfix #255 - Hotfix - Fixes unwanted "Custom Feed" API call

### DIFF
--- a/src/components/Feed/FeedEditModal.vue
+++ b/src/components/Feed/FeedEditModal.vue
@@ -925,7 +925,7 @@ export default defineComponent({
             else if(newType != oldType){
                 this.currentPage = 1;
                 this.selectedFeedType = newType;
-                if(newType = FeedEnums.Types.FeedGenerator) this.getCustomFeeds();
+                if(newType == FeedEnums.Types.FeedGenerator) this.getCustomFeeds();
             }
         },
         summary(newSummary:string,oldSummary:string){


### PR DESCRIPTION
- Added quick fix that prevents a "ghost" API call for a list of Popular Feed Generators from occuring when navigating to the 2nd page of `FeedEditModal`.