### PR TITLE
Hotfix #177 - Update `AvatarRound` -> `UserFocusModal` navigation

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -36,7 +36,6 @@ declare module 'vue' {
     Hashtag: typeof import('./src/components/Utilities/Hashtag.vue')['default']
     Hyperlink: typeof import('./src/components/Utilities/Hyperlink.vue')['default']
     'ILogos:bluesky': typeof import('~icons/logos/bluesky')['default']
-    Image: typeof import('./src/components/Utilities/Image.vue')['default']
     ImageContainer: typeof import('./src/components/Utilities/ImageContainer.vue')['default']
     ImageLoader: typeof import('./src/components/Utilities/ImageLoader.vue')['default']
     'IMdi:accounts': typeof import('~icons/mdi/accounts')['default']

--- a/src/components/Utilities/AvatarRound.vue
+++ b/src/components/Utilities/AvatarRound.vue
@@ -23,6 +23,7 @@ import { IOptionMenuItem, ItemType } from './OptionsMenu.vue';
 import { AddFeedToList, PrepareFeedData } from '../../state/FeedList.vue';
 import { FeedEnums } from '../../enums/FeedEnums';
 import ImageLoader from './ImageLoader.vue';
+import { UserFocusModalState } from '../../state/UserFocusModalState.vue';
 
 /**
  * Method that adds a new User feed to the displayed list of Feeds based on
@@ -85,7 +86,9 @@ export default defineComponent({
         displaySelectedUserAccount(e:Event){
             //Cancel displaying `AccountPeek`
             AccountPeekState.cancelUserPeek(true);
-            this.$router.push(`/profile/${this.handle}`);
+            if(typeof UserFocusModalState.currentUserPageDetails.ProfileData != 'undefined' &&
+            UserFocusModalState.currentUserPageDetails.ProfileData.handle == this.handle) return; //do nothing if already on destination User page
+            else this.$router.push(`/profile/${this.handle}`);
             e.stopPropagation();//Prevent click "bubbling"
         },
         /**


### PR DESCRIPTION
- Fixed issue where clicking on a `AvatarRound` held in `UserFocusModal` that was associated with the currently viewed User Account would change the page title to "Loading... | moongate".