### PR TITLE
Bugfix #260 - Fix [Post to Parent Post] navigation issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moongate",
   "private": true,
-  "version": "0.8.5",
+  "version": "0.8.7",
   "type": "module",
   "scripts": {
     "predev": "node update-version.cjs",

--- a/src/components/Feed/FeedColumn.vue
+++ b/src/components/Feed/FeedColumn.vue
@@ -158,7 +158,7 @@
                     <div v-for="n in feedData?.data" data-test="feedColumn-post" :key="generateUniqueIdForPost(n)" class="rounded bg-feedColumnBG border border-outline w-full
                     drop-shadow-md justify-between text-sm">
                         <FocusFeedPost tabindex="-1" class="border-0" :post-data="({$type:'app.bsky.feed.defs#postView',...(n as FeedViewPost).post} as PostView)"
-                        :post-reason="(n as FeedViewPost).reason" :reply="(n as FeedViewPost).reply"
+                        :post-reason="(n as FeedViewPost).reason" :reply-ref="(n as FeedViewPost).reply"
                         :is-feed-post-style="true"/>
                     </div>
                 </div>

--- a/src/components/Feed/FocusFeedPost.vue
+++ b/src/components/Feed/FocusFeedPost.vue
@@ -99,7 +99,7 @@
             </div>
         </div>
         <div v-else-if="postToShow && isPostReply && !isReplyStyle" @click="openPostReply(getReplyParentURI)"
-        title="Open Reply Parent"
+        data-testid="focusfeedpost-view-parent" title="Open Reply Parent"
         class="flex self-start py-0.5 px-2 rounded-md text-[10px] leading-3 text-primary
         bg-btn hover:bg-btnHover cursor-pointer select-none">
             Reply

--- a/src/components/Feed/FocusFeedPost.vue
+++ b/src/components/Feed/FocusFeedPost.vue
@@ -568,7 +568,7 @@ export default defineComponent({
             //ThreadViewPost that is reply (seen in Feed)
             if(this.reply && isPostView(this.reply.parent)) return true;
             //Standalone PostView that is reply (likely seen as bookmark)
-            else if(isMain(this.postToShow.record) && typeof (this.postToShow.record as Main).reply != 'undefined' && isPostView(this.postToShow)) return true;
+            else if(isPostView(this.postToShow) && isMain(this.postToShow.record) && typeof (this.postToShow.record as Main).reply != 'undefined' ) return true; //there's no way to know the state of the reply Post until accessing it when using this object...
             return false;
         },
         /**Return the URI pointing to the Parent of this Post, if it exists. */

--- a/src/components/Feed/FocusFeedPost.vue
+++ b/src/components/Feed/FocusFeedPost.vue
@@ -98,12 +98,14 @@
                 {{ convertToShortTimestamp(postReason.indexedAt) }}
             </div>
         </div>
-        <div v-else-if="postToShow && isPostReply && !isReplyStyle" @click="openPostReply(getReplyParentURI)"
-        data-testid="focusfeedpost-view-parent" title="Open Reply Parent"
-        class="flex self-start py-0.5 px-2 rounded-md text-[10px] leading-3 text-primary
-        bg-btn hover:bg-btnHover cursor-pointer select-none">
-            Reply
-        </div>
+        <button v-else-if="postToShow && isPostReply.isReply && !isReplyStyle" @click="openPostParent(getParentPostURI)"
+        data-testid="focusfeedpost-view-parent" :disabled="isAwaitingParentPostHandle" title="Open Parent Post"
+        class="flex gap-1 items-center self-start py-0.5 px-1 rounded-md text-[10px] leading-3 text-primary
+        bg-btn hover:bg-btnHover hover:border-transparent disabled:bg-disabled cursor-pointer
+        disabled:cursor-default shadow-none select-none">
+            <i-mingcute:loading-fill v-if="isAwaitingParentPostHandle" class="spinner"/>
+            <div>View Parent</div>
+        </button>
         <div data-testid="focusFeedPost" class="flex w-full">
             <div>
                 <AvatarRound v-if="isReplyStyle" :avatar="postToShow.author.avatar" :did="postToShow.author.did" :handle="postToShow.author.handle"/>
@@ -185,12 +187,12 @@ import EmbedExternal from '../Utilities/EmbedExternal.vue';
 import PostInteractionIcons from '../Post/PostInteractionIcons.vue';
 import { isImage, View, ViewImage } from '@atproto/api/dist/client/types/app/bsky/embed/images';
 import { isView as isViewForRecordWithMedia, View as ViewForRecordWithMedia} from "@atproto/api/dist/client/types/app/bsky/embed/recordWithMedia";
-import { postDetails, showFocusModal } from '../../state/PostDetails.vue';
+import { postDetails } from '../../state/PostDetails.vue';
 import RichPostTextBsky from '../Utilities/RichPostTextBsky.vue';
 import { isListView, isStarterPackViewBasic, ListView, StarterPackViewBasic } from '@atproto/api/dist/client/types/app/bsky/graph/defs';
 import VerifiedBadge from '../Utilities/VerifiedBadge.vue';
 import { isMain, Main, Record } from '@atproto/api/dist/client/types/app/bsky/feed/post';
-import { toggleBlock } from '../../lib/api/User.vue';
+import { getUserProfile, toggleBlock } from '../../lib/api/User.vue';
 import { BookmarkPost, getPostImages, RemoveBookmark } from '../../lib/api/Post.vue';
 import { AppState, toast } from '../../state/AppState.vue';
 import { LabelerView } from '@atproto/api/dist/client/types/app/bsky/labeler/defs';
@@ -223,7 +225,8 @@ export default defineComponent({
         },
         replyIndex:Number,
         totalReplies:Number,
-        reply: Object as PropType<ReplyRef>
+        /**The `ReplyRef` object associated with the Post to display, if there is one. */
+        replyRef: Object as PropType<ReplyRef>
     },
     data(){
         return{
@@ -254,6 +257,8 @@ export default defineComponent({
             isAwaitingAccountBlockAction:false,
             /**Are we currently waiting for an action relating to saving/removing a Post bookmark to finish? */
             isAwaitingBookmarkUpdate:false,
+            /**Are we currently waiting for the account handle of the parent Post creator to be resolved? */
+            isAwaitingParentPostHandle:false,
         }
     },
     emits:{
@@ -321,9 +326,39 @@ export default defineComponent({
             // else
                 return `/profile/${this.postToShow.author.handle}/post/${postDid}`;
         },
-        openPostReply(postURI:string|undefined, mediaIndex:number=0){
-            if(typeof this.postToShow != 'undefined' && typeof postURI != 'undefined'){
-                showFocusModal(postURI, mediaIndex);
+        /**
+         * Method used to open the parent Post of this Post in `PostFocusModal`, if it exists.
+         * @param postURI The URI that points to the parent post.
+         * @param mediaIndex The media index to initially show when displaying the parent post.
+         */
+        async openPostParent(postURI:string|undefined, mediaIndex:number=0){
+            if(typeof this.postToShow != 'undefined' && typeof postURI != 'undefined' && !this.isAwaitingParentPostHandle){
+                let accountDid = postURI.split('/')[2];
+                let handle = '';
+                if(this.isPostReply.hasFullParentInfo){
+                    //If reply reference exists and parent is a PostView object
+                    if(typeof this.replyRef != 'undefined' && isPostView(this.replyRef.parent)) handle = this.replyRef.parent.author.handle;
+                    //need to handle `NotFoundPost` and `BlockedPost` situations as well
+                }
+                else{
+                    //disable "View Parent of Reply" button until this resolves
+                    this.isAwaitingParentPostHandle = true;
+                    await getUserProfile(accountDid).then(res => {
+                        handle = res.data.handle;
+                    })
+                    .catch(err => {
+                        toast.add({summary:'Error Getting Parent Post', detail:`${err}`, severity:'error', group:'tr', life:3000});
+                        //add route navigation to display current post once `UserFocusModal` has support for displaying parent/root posts
+                    })
+                    .finally(()=>{
+                        //re-enable "View Parent of Reply" button
+                        this.isAwaitingParentPostHandle = false;
+                    })
+                }
+                if(handle.trim() != ''){
+                    let postDid:string|undefined = postURI.split('/').pop();
+                    this.$router.push(`/profile/${handle}/post/${postDid}`);
+                }
             }
         },
         /**
@@ -561,21 +596,21 @@ export default defineComponent({
             return false;
         },
         /**
-         * Method used to check if this Post is a reply. Ensures it the `parent`
-         * is a `PostView` as well.
+         * Method used to check if this Post is a reply.
          */
-        isPostReply(){
+        isPostReply():{isReply:boolean,hasFullParentInfo:boolean}{
             //ThreadViewPost that is reply (seen in Feed)
-            if(this.reply && isPostView(this.reply.parent)) return true;
+            if(this.replyRef && isPostView(this.replyRef.parent)) return {isReply:true,hasFullParentInfo:true};
             //Standalone PostView that is reply (likely seen as bookmark)
-            else if(isPostView(this.postToShow) && isMain(this.postToShow.record) && typeof (this.postToShow.record as Main).reply != 'undefined' ) return true; //there's no way to know the state of the reply Post until accessing it when using this object...
-            return false;
+            else if(isPostView(this.postToShow) && isMain(this.postToShow.record) && typeof (this.postToShow.record as Main).reply != 'undefined')
+                return {isReply:true,hasFullParentInfo:false}; //there's no way to know the state of the reply Post until accessing it when using this object...
+            return {isReply:false,hasFullParentInfo:false};
         },
         /**Return the URI pointing to the Parent of this Post, if it exists. */
-        getReplyParentURI():string|undefined{
-            if(this.isPostReply){
-                if(typeof this.reply != 'undefined' && isPostView(this.reply.parent)) return this.reply.parent.uri;
-                else if(isMain(this.postToShow.record) && typeof (this.postToShow.record as Main).reply != 'undefined') return (this.postToShow.record as Main).reply?.parent.uri;
+        getParentPostURI():string|undefined{
+            if(this.isPostReply.isReply){
+                if(typeof this.replyRef != 'undefined' && isPostView(this.replyRef.parent)) return this.replyRef.parent.uri;
+                else if(isPostView(this.postToShow) && isMain(this.postToShow.record) && typeof (this.postToShow.record as Main).reply != 'undefined') return (this.postToShow.record as Main).reply!.parent.uri;
             }
         },
         /**Is the account associated with the currently displayed Post blocked by the logged in User? */

--- a/src/components/Login/LoginModal.vue
+++ b/src/components/Login/LoginModal.vue
@@ -17,7 +17,7 @@
                             <i-mdi:spy class="shrink-0"/>
                             <i-mdi:chevron-right class="ml-auto text-3xl"/>
                         </RadioBarButton>
-                        <RadioBarButton @click="loginToAccountClicked" :selected="AppSettingsState.Settings.savedAccountState.state == LoginState.Authorized">
+                        <RadioBarButton data-testid="login-to-account-button" @click="loginToAccountClicked" :selected="AppSettingsState.Settings.savedAccountState.state == LoginState.Authorized">
                              <div class="flex flex-col md:gap-1.5 md:flex-row md:items-center text-left">
                                 <div class="flex gap-1.5 items-center">
                                     <div class="text-xs md:text-base text-nowrap">Login to account</div>
@@ -147,7 +147,7 @@
             <div class="flex">
                 <SquareButton v-if="currentPage != 0" @click="clickedBackButton" :is-awaiting-response="attemptingLogin"
                 class="mr-auto bg-btn hover:bg-btnHover w-12">Back</SquareButton>
-                <SquareButton v-if="currentPage == modalPage.length-1" @click="loginAccount" :is-disabled="isLoginDisabled"
+                <SquareButton data-testid="login-button" v-if="currentPage == modalPage.length-1" @click="loginAccount" :is-disabled="isLoginDisabled"
                 :is-awaiting-response="attemptingLogin" :title="titleMessage"
                 class="bg-loginBtn font-semibold transition-colors hover:bg-loginBtnHover
                 text-primary md:self-end md:w-40 h-10">Login</SquareButton>

--- a/src/components/Navbar/UserButton.vue
+++ b/src/components/Navbar/UserButton.vue
@@ -1,6 +1,6 @@
 <template>
     <div @click="onUserButtonClick" :onmouseenter="displayButtonTooltip" :onmouseleave="hideButtonTooltip"
-        @contextmenu.prevent class="relative cursor-pointer">
+        @contextmenu.prevent class="relative cursor-pointer" data-testid="userbutton">
         <div class="absolute z-10 border-[3px] border-sidebar w-3 -left-1 box-content aspect-square rounded-full" :class="GetLoginStateColor"
         :title="GetLoginStateText"></div>
         <a class="group relative flex justify-center aspect-square
@@ -10,7 +10,7 @@
                 <i-mingcute:key-2-line v-if="!AppState.canBrowse || !isVisible" class=" absolute h-full text-2xl transition-colors text-primary group-hover:text-loginHighlight"/>
                 <div v-else-if="AppState.canBrowse || isVisible" class="absolute flex h-full w-full justify-center">
                     {{ void "User PFP" }}
-                    <div v-if="AppState.isAuthBrowsing" class="absolute flex h-full w-full rounded-full bg-contain"
+                    <div data-testid="userbutton-user-avatar" v-if="AppState.isAuthBrowsing" class="absolute flex h-full w-full rounded-full bg-contain"
                         :style="`background-image: url(${AppState.currentPFP});`">
                     </div>
                     <div v-if="AppState.isAuthBrowsing && AppState.currentPFP == ''" class="flex items-center text-primary text-2xl">

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -376,6 +376,7 @@ export default defineComponent({
                 // toast.add(HandleAPIError(err, 'Error getting Post thread for focus modal'))
                 console.log('PostFocusModal - error getting Post Thread data')
                 console.log(err)
+                postDetails.currentThreadView = this.threadNavHistory[0] = emptyPostThread;
             })
             .finally(()=>{
                 postDetails.isAwaitingFocusData = false;

--- a/src/components/Settings/AboutAppModal.vue
+++ b/src/components/Settings/AboutAppModal.vue
@@ -33,6 +33,23 @@
             <div class="flex flex-col overflow-y-auto">
                 <div class="px-4 text-xl font-semibold">Changelog:</div>
                 <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
+                    <div class="font-semibold">January 22nd 2026</div>
+                    <ul class="list-disc list-inside h-full py-1 text-sm">
+                        <li>Updated "View Parent of Post" button that is displayed on "reply posts".
+                            <ul class="list-disc list-inside h-full text-sm">
+                                <li>Changed label from "Reply" to "View Parent".</li>
+                                <li>Modified click behavior so that opening a Post that has been deleted is handled (albeit in a basic manner at the moment).</li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
+                <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
+                    <div class="font-semibold">January 18th 2026</div>
+                    <ul class="list-disc list-inside h-full py-1 text-sm">
+                        <li>Updated how various app components handle loading images.</li>
+                    </ul>
+                </div>
+                <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
                     <div class="font-semibold">January 1st 2026</div>
                     <ul class="list-disc list-inside h-full py-1 text-sm">
                         <li>Updated app to use Routes during interactions.

--- a/src/components/User/UserFocusModal.vue
+++ b/src/components/User/UserFocusModal.vue
@@ -240,8 +240,7 @@
                             </div>
                             <div v-else-if="!awaitingProfileData && !isNavigatingHistory" v-for="n in UserFocusModalState.currentUserPageDetails.FeedData.data as FeedViewPost[]"
                             class="w-full shrink-0s">
-                                <!-- <FocusFeedPost :post-data="n.post" :post-reason="n.reason" :reply="n.reply" @focus-post-avatar-clicked="updateDisplayedData"/> -->
-                                <FocusFeedPost :post-data="({$type:'app.bsky.feed.defs#postView',...n.post} as PostView)" :post-reason="n.reason" :reply="n.reply" @focus-post-avatar-clicked="updateDisplayedData"/>
+                                <FocusFeedPost :post-data="({$type:'app.bsky.feed.defs#postView',...n.post} as PostView)" :post-reason="n.reason" :reply-ref="n.reply" @focus-post-avatar-clicked="updateDisplayedData"/>
                             </div>
                             <div v-if="!awaitingProfileData && !UserFocusModalState.currentUserPageDetails.FeedData.cursor"
                             class="flex justify-center rounded p-1 gap-1 w-full items-center

--- a/src/fake-data/DataFactory.ts
+++ b/src/fake-data/DataFactory.ts
@@ -8,6 +8,7 @@ import { TrendView } from "@atproto/api/dist/client/types/app/bsky/unspecced/def
 import { GenerateCID } from "../helpers/generators";
 import { ProfileViewBasic, ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 import { AppBskyEmbedExternal, AppBskyEmbedImages } from "@atproto/api/dist/client";
+import { BookmarkView } from "@atproto/api/dist/client/types/app/bsky/bookmark/defs";
 
 /**
  * Type indicating the state of a Parent Post - is it a `PostView` (standard), Not Found (i.e. deleted), Blocked,
@@ -267,6 +268,33 @@ export async function CreateUserProfile(handle:string,displayName:string|undefin
     profile.description = `Hello! I am a User Profile created for testing this app.\nDID:${profile.did}\nHandle:${profile.handle}`
     if(typeof displayName != 'undefined') profile.displayName = displayName;
     return profile;
+}
+
+/**
+ * Method used to create a `BookmarkView` object representing a bookmarked Post.
+ * @param handle The handle of the User who made the bookmarked Post.
+ * @param postText The text content of the bookmarked Post.
+ * @param displayName The display name of the User who made the bookmarked Post. If none is provided, the handle will be used.
+ * @param postTime The time that the bookmarked Post was created.
+ * @returns The created `BookmarkView` object.
+ */
+export async function CreateBookmarkView(handle:string,postText:string='',displayName:string='',postTime:Date=new Date()):Promise<BookmarkView>{
+    let indexTime = postTime.toISOString();
+    let cid = `bookmark${handle}_${1}`;
+    await GenerateCID(cid).then(res => {
+        cid = res.toString();
+    })
+    let bItem:$Typed<PostView>;
+    await CreatePostView(handle,postText,displayName,postTime).then(res => bItem = res);
+    let bookmark:BookmarkView = {
+        item:bItem!,
+        subject:{//These values are expected to be unused in testing for now
+            cid:cid,
+            uri:'at://did:plc:nowhere'
+        },
+        createdAt:indexTime
+    }
+    return bookmark;
 }
 
 /**

--- a/src/fake-data/DataFactory.ts
+++ b/src/fake-data/DataFactory.ts
@@ -9,6 +9,7 @@ import { GenerateCID } from "../helpers/generators";
 import { ProfileViewBasic, ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 import { AppBskyEmbedExternal, AppBskyEmbedImages } from "@atproto/api/dist/client";
 import { BookmarkView } from "@atproto/api/dist/client/types/app/bsky/bookmark/defs";
+import { OutputSchema } from "@atproto/api/dist/client/types/com/atproto/server/createSession";
 
 /**
  * Type indicating the state of a Parent Post - is it a `PostView` (standard), Not Found (i.e. deleted), Blocked,
@@ -595,4 +596,51 @@ export function CreateEmbedGIF():$Typed<AppBskyEmbedExternal.View>{
         }
     }
     return emb;
+}
+
+/**
+ * Method used to create a dummy session response. Currently used to mock logging into Bluesky.
+ * @param handle The handle to use in the session response.
+ * @param did The DID to use in the session response. NOTE: If trying access features that require an
+ * account match (i.e. Bookmarks) the DID of the User Profile and Session Response must match.
+ * @returns The created session response object.
+ */
+export function CreateLoginSessionResponse(handle:string="test-session.bsky.social",did:string="did:plc:test-session"):OutputSchema{
+    let response:OutputSchema = {
+        did: did,
+        didDoc: {
+            "@context": [
+                "https://www.w3.org/ns/did/v1",
+                "https://w3id.org/security/multikey/v1",
+                "https://w3id.org/security/suites/secp256k1-2019/v1"
+            ],
+            id: "did:plc:test-session",
+            alsoKnownAs: [
+                "at://test-session.bsky.social"
+            ],
+            verificationMethod: [
+                {
+                    id: "did:plc:test-session#atproto",
+                    type: "Multikey",
+                    controller: "did:plc:test-session",
+                    publicKeyMultibase: "zQ3shkYUSJxz7PmCaGznbNR5oMCLKsjC7foCUVLVhxhioa5fa"
+                }
+            ],
+            service: [
+                {
+                    id: "#atproto_pds",
+                    type: "AtprotoPersonalDataServer",
+                    serviceEndpoint: "https://hollowfoot.us-west.host.bsky.network"
+                }
+            ]
+        },
+        handle: handle,
+        email: "testSession@mail.com",
+        emailConfirmed: true,
+        emailAuthFactor: false,
+        accessJwt: "testAccessJwt",
+        refreshJwt: "testRefreshJwt",
+        active: true
+    }
+    return response;
 }

--- a/src/fake-data/DataFactory.ts
+++ b/src/fake-data/DataFactory.ts
@@ -1,4 +1,4 @@
-import { FeedViewPost, ThreadViewPost } from "@atproto/api/dist/client/types/app/bsky/feed/defs";
+import { FeedViewPost, NotFoundPost, PostView, ThreadViewPost } from "@atproto/api/dist/client/types/app/bsky/feed/defs";
 import { IFeedDescription, IFeedListing } from "../interfaces/FeedInterfaces";
 import { FeedEnums } from "../enums/FeedEnums";
 import { View } from "@atproto/api/dist/client/types/app/bsky/embed/external";
@@ -10,23 +10,81 @@ import { ProfileViewBasic, ProfileViewDetailed } from "@atproto/api/dist/client/
 import { AppBskyEmbedExternal, AppBskyEmbedImages } from "@atproto/api/dist/client";
 
 /**
+ * Type indicating the state of a Parent Post - is it a `PostView` (standard), Not Found (i.e. deleted), Blocked,
+ * or does it not exist at all.
+ */
+type ParentState = 'PostView'|'NotFoundPost'|'BlockedPost'|'None';
+
+/**
+ * Method used to create a dummy `PostView` object for testing purposes.
+ * @param handle The handle of the User who made the Post.
+ * @param postText The text content of the Post.
+ * @param displayName The display name of the User who made the Post. If none is provided, the handle will be used.
+ * @param postTime The time that the Post was created.
+ * @returns The created `PostView` object.
+ */
+export async function CreatePostView(handle:string,postText:string='',displayName:string='',postTime:Date=new Date()):Promise<$Typed<PostView>>{
+    let indexTime = postTime.toISOString();
+    let cid = `author_${handle}_${1}`;
+    await GenerateCID(`author_${handle}_${1}`).then(res => {
+        cid = res.toString();
+    })
+    let post:$Typed<PostView> = {
+        $type:"app.bsky.feed.defs#postView",
+        author:{
+            did:`did:plc:fake_${1}`,
+            handle:handle,
+            displayName:displayName.trim() != '' ? displayName : (handle[0].toUpperCase()+handle.slice(1)).replace(/_/g,' ')
+        },
+        cid:cid,
+        indexedAt:indexTime,
+        record: {
+            $type: "app.bsky.feed.post",
+            createdAt: indexTime,
+            langs: [
+                "en-US"
+            ],
+            text: postText.trim() == '' ? `Hello World! My name ${handle}.` : postText
+        },
+        uri:'at://did:plc:nowhere'
+    }
+    return post;
+}
+
+/**
+ * Method used to create a dummy `NotFoundPost` object for testing purposes.
+ * @returns A `$Typed<NotFoundPost>` object.
+ */
+export function CreateNotFoundPost():$Typed<NotFoundPost>{
+    let nfpost:$Typed<NotFoundPost> = {
+        $type:"app.bsky.feed.defs#notFoundPost",
+        notFound:true,
+        uri:'at://did:plc:notFoundPost'
+    }
+    return nfpost;
+}
+
+/**
  * Method used to create a dummy `FeedViewPost` object for testing purposes.
  * MUST AWAIT IN ORDER FOR CID TO BE GENERATED.
  * @param handle The handle of the User who made the Post.
  * @param postText The text content of the Post.
  * @param includeEmbedLink Should this post contain an external link embed?
  * @param displayName The display name of the User who made the Post. If none is provided, the handle will be used.
+ * @param isPinned Should the created Post be a pinned post?
+ * @param postTime The time that the Post was created.
+ * @param parentState The "state" of the Parent post of the Post being created. Options are No Parent,
+ * Standard Parent Post (value currently hardcoded), `NotFoundPost` Parent or `BlockedPost` Parent.
  * @returns The created `FeedViewPost` object.
  */
 export async function CreateFeedViewPost(handle:string, postText:string='', includeEmbedLink:boolean=false,
-    displayName:string='',postTime:Date=new Date(),isPinned:boolean=false):Promise<FeedViewPost>{
+    displayName:string='',postTime:Date=new Date(),isPinned:boolean=false,parentState:ParentState='None'):Promise<FeedViewPost>{
     // let currentTime = new Date();
     // currentTime.setTime(currentTime.getTime()-(1*60*1000));
     // postTime.setTime(postTime.getTime()-(1*60*1000));
     // let indexTime = currentTime.toISOString();
     let indexTime = postTime.toISOString();
     let cid = `author_${handle}_${1}`;
-    // cid = "bafyreifzelycxgfy7niauhzchi34z6avvb6fczinbcyj3y6465szpf5f7a";
     await GenerateCID(`author_${handle}_${1}`).then(res => {
         cid = res.toString();
     })
@@ -57,6 +115,51 @@ export async function CreateFeedViewPost(handle:string, postText:string='', incl
                 $type: "app.bsky.feed.defs#reasonPin"
             }
         }
+    }
+    switch (parentState) {
+        case "PostView":
+            let parentPost:$Typed<PostView>;
+            await CreatePostView('parent.to.reply',"I'm the parent!",'Parent Post').then(res =>{
+                parentPost = res;
+                post.reply = {
+                    parent:parentPost,
+                    root:parentPost
+                }
+                post.post.record = {
+                    reply:{
+                        parent:{
+                            cid:parentPost.cid,
+                            uri:parentPost.uri
+                        },
+                    },
+                    //root not implemented
+                    ...post.post.record
+                }
+            })
+            break;
+        case "NotFoundPost":
+            let nfPost = CreateNotFoundPost();
+            let nfCID:string;
+            await GenerateCID(`author_${handle}_nf`).then(res => {
+                nfCID = res.toString();
+                post.reply = {
+                    parent:nfPost,
+                    root:nfPost
+                }
+                post.post.record = {
+                    reply:{
+                        parent:{
+                            cid:nfCID,
+                            uri:nfPost.uri
+                        },
+                    },
+                    //root not implemented
+                    ...post.post.record
+                }
+            })
+            break;
+        default:
+            break;
     }
     return post;
 }

--- a/src/fake-data/DataFactory.ts
+++ b/src/fake-data/DataFactory.ts
@@ -10,6 +10,7 @@ import { ProfileViewBasic, ProfileViewDetailed } from "@atproto/api/dist/client/
 import { AppBskyEmbedExternal, AppBskyEmbedImages } from "@atproto/api/dist/client";
 import { BookmarkView } from "@atproto/api/dist/client/types/app/bsky/bookmark/defs";
 import { OutputSchema } from "@atproto/api/dist/client/types/com/atproto/server/createSession";
+import { Main } from '@atproto/api/dist/client/types/app/bsky/feed/post';
 
 /**
  * Type indicating the state of a Parent Post - is it a `PostView` (standard), Not Found (i.e. deleted), Blocked,
@@ -277,9 +278,12 @@ export async function CreateUserProfile(handle:string,displayName:string|undefin
  * @param postText The text content of the bookmarked Post.
  * @param displayName The display name of the User who made the bookmarked Post. If none is provided, the handle will be used.
  * @param postTime The time that the bookmarked Post was created.
+ * @param parentState The "state" of the Parent post of the bookmarked Post being created. Options are No Parent,
+ * Standard Parent Post (value currently hardcoded), `NotFoundPost` Parent or `BlockedPost` Parent.
  * @returns The created `BookmarkView` object.
  */
-export async function CreateBookmarkView(handle:string,postText:string='',displayName:string='',postTime:Date=new Date()):Promise<BookmarkView>{
+export async function CreateBookmarkView(handle:string,postText:string='',displayName:string='',postTime:Date=new Date(),
+parentState:ParentState='None'):Promise<BookmarkView>{
     let indexTime = postTime.toISOString();
     let cid = `bookmark${handle}_${1}`;
     await GenerateCID(cid).then(res => {
@@ -294,6 +298,45 @@ export async function CreateBookmarkView(handle:string,postText:string='',displa
             uri:'at://did:plc:nowhere'
         },
         createdAt:indexTime
+    }
+    switch (parentState) {
+        case "PostView":
+            let parentPost:$Typed<PostView>;
+            await CreatePostView('parent.to.reply',"I'm the parent!",'Parent Post').then(res =>{
+                parentPost = res;
+                (bItem.record as Main).reply = {
+                    parent:{
+                        cid:parentPost.cid,
+                        uri:parentPost.uri
+                    },
+                    root:{
+                        cid:parentPost.cid,
+                        uri:parentPost.uri
+                    }
+                }
+            })
+            break;
+        case "NotFoundPost":
+            let nfPost = CreateNotFoundPost();
+            let nfCID:string;
+            await GenerateCID(`author_${handle}_nf`).then(res => {
+                nfCID = res.toString();
+                (bItem.record as Main).reply = {
+                    // parent:nfPost,
+                    // root:nfPost
+                    parent:{
+                        cid:nfCID,
+                        uri:nfPost.uri
+                    },
+                    root:{
+                        cid:nfCID,
+                        uri:nfPost.uri
+                    }
+                }
+            })
+            break;
+        default:
+            break;
     }
     return bookmark;
 }

--- a/tests/FocusFeedPost.spec.ts
+++ b/tests/FocusFeedPost.spec.ts
@@ -1,0 +1,87 @@
+import test, { expect } from "@playwright/test";
+import { CreateFeedViewPost, CreateThreadViewPost, CreateUserProfile } from "../src/fake-data/DataFactory";
+import { $Typed, AppBskyFeedGetPostThread } from "@atproto/api";
+import { FeedViewPost, ThreadViewPost } from "@atproto/api/dist/client/types/app/bsky/feed/defs";
+
+
+let handle1:string = 'tester.da.playwright';
+let handle2:string = 'i.am.very.secretive';
+let displayName1:string = 'I AM A TESTER';
+let displayName2:string = `tester don't play that`;
+let profile1 = await CreateUserProfile(handle1,displayName2);
+let profile2 = await CreateUserProfile(handle2);
+let post1:AppBskyFeedGetPostThread.OutputSchema;
+let postWithParentThatExists:FeedViewPost;
+let postWithNotFoundPostParent:FeedViewPost;
+let postText1 = "Lorem ipsum dipsum, dimsum, mmm I'm hungry";
+let postText2 = 'I am replying to a post. My parent has not been deleted.';
+let postText3 = 'I am replying to a post. My parent has been deleted.😢';
+let currentDateTime = new Date();
+await CreateThreadViewPost(handle1,postText1,{activate:true,type:'img'},false,{activate:true,images:true,type:'ext_gif'},'I AM A TESTER').then(res =>{
+    post1 = {thread:res as $Typed<ThreadViewPost>}
+})
+await CreateFeedViewPost(handle1,postText2,undefined,displayName1,currentDateTime,undefined,"PostView").then(res => {
+    postWithParentThatExists = res;
+})
+await CreateFeedViewPost(handle1,postText3,undefined,displayName1,currentDateTime,undefined,"NotFoundPost").then(res => {
+    postWithNotFoundPostParent = res;
+})
+
+test.beforeEach(async ({ context }) => {
+    await context.route(/app.bsky.feed.getPostThread/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(post1)
+        });
+    });
+    // await context.route(/app.bsky.feed.getAuthorFeed/, route => {
+    //     route.fulfill({
+    //         status: 200,
+    //         headers: { 'Content-Type': 'application/json' },
+    //         body:JSON.stringify({feed:[post2]})
+    //     });
+    // });
+})
+
+test('FocusFeedPost with valid reply parent should display "View Parent of Reply" button', async ({context, page}) => {
+    await page.route(/app.bsky.actor.getProfile/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(profile1)
+        });
+    });
+    await page.route(/app.bsky.feed.getAuthorFeed/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify({feed:[postWithParentThatExists]})
+        });
+    });
+    await page.goto(`/profile/${handle1}`,{waitUntil:'networkidle'});
+    // await expect(page).toHaveTitle(`${displayName2}'s Account | moongate`);
+    await page.getByText(postText2).scrollIntoViewIfNeeded();
+    await expect(page.getByTestId('focusfeedpost-view-parent')).toBeVisible();
+})
+
+test('FocusFeedPost with NotFoundPost reply parent should not display "View Parent of Reply" button', async ({context, page}) => {
+    await page.route(/app.bsky.actor.getProfile/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(profile1)
+        });
+    });
+    await page.route(/app.bsky.feed.getAuthorFeed/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify({feed:[postWithNotFoundPostParent]})
+        });
+    });
+    await page.goto(`/profile/${handle1}`,{waitUntil:'networkidle'});
+    // await expect(page).toHaveTitle(`${displayName2}'s Account | moongate`);
+    await page.getByText(postText3).scrollIntoViewIfNeeded();
+    await expect(page.getByTestId('focusfeedpost-view-parent')).toBeHidden();
+})

--- a/tests/FocusFeedPost.spec.ts
+++ b/tests/FocusFeedPost.spec.ts
@@ -1,5 +1,5 @@
 import test, { expect } from "@playwright/test";
-import { CreateBookmarkView, CreateFeedViewPost, CreateThreadViewPost, CreateUserProfile } from "../src/fake-data/DataFactory";
+import { CreateBookmarkView, CreateFeedViewPost, CreateLoginSessionResponse, CreateThreadViewPost, CreateUserProfile } from "../src/fake-data/DataFactory";
 import { $Typed, AppBskyFeedGetPostThread } from "@atproto/api";
 import { FeedViewPost, ThreadViewPost } from "@atproto/api/dist/client/types/app/bsky/feed/defs";
 import { BookmarkView } from "@atproto/api/dist/client/types/app/bsky/bookmark/defs";
@@ -48,51 +48,6 @@ test.beforeEach(async ({ context }) => {
     //         body:JSON.stringify({feed:[post2]})
     //     });
     // });
-    //Intercept any attempt to log in and return dummy session data
-    await context.route(/com.atproto.server.createSession/, route => {
-        route.fulfill({
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-            body:JSON.stringify(
-                {
-                    did: "did:plc:test-session",
-                    didDoc: {
-                        "@context": [
-                            "https://www.w3.org/ns/did/v1",
-                            "https://w3id.org/security/multikey/v1",
-                            "https://w3id.org/security/suites/secp256k1-2019/v1"
-                        ],
-                        id: "did:plc:test-session",
-                        alsoKnownAs: [
-                            "at://test-session.bsky.social"
-                        ],
-                        verificationMethod: [
-                            {
-                                id: "did:plc:test-session#atproto",
-                                type: "Multikey",
-                                controller: "did:plc:test-session",
-                                publicKeyMultibase: "zQ3shkYUSJxz7PmCaGznbNR5oMCLKsjC7foCUVLVhxhioa5fa"
-                            }
-                        ],
-                        service: [
-                            {
-                                id: "#atproto_pds",
-                                type: "AtprotoPersonalDataServer",
-                                serviceEndpoint: "https://hollowfoot.us-west.host.bsky.network"
-                            }
-                        ]
-                    },
-                    handle: "test-session.bsky.social",
-                    email: "testSession@mail.com",
-                    emailConfirmed: true,
-                    emailAuthFactor: false,
-                    accessJwt: "testAccessJwt",
-                    refreshJwt: "testRefreshJwt",
-                    active: true
-                }
-            )
-        });
-    });
 })
 
 test('FocusFeedPost with valid reply parent should display "View Parent of Reply" button', async ({context, page}) => {
@@ -137,8 +92,15 @@ test('FocusFeedPost with NotFoundPost reply parent should not display "View Pare
     await expect(page.getByTestId('focusfeedpost-view-parent')).toBeHidden();
 })
 
-test('Bookmark FocusFeedPost with PostView reply parent should display "View Parent of Reply" button', async ({context, page}) => {
-    // console.log(JSON.stringify(bookmarkWithParentThatExist));
+test('Bookmarked FocusFeedPost with PostView reply parent should display "View Parent of Reply" button', async ({context, page},testInfo) => {
+    let sessionResponse = CreateLoginSessionResponse(profile1.handle,profile1.did);
+    await page.route(/com.atproto.server.createSession/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(sessionResponse)
+        });
+    });
     await page.route(/app.bsky.actor.getProfile/, route => {
         route.fulfill({
             status: 200,
@@ -157,7 +119,7 @@ test('Bookmark FocusFeedPost with PostView reply parent should display "View Par
         route.fulfill({
             status: 200,
             headers: { 'Content-Type': 'application/json' },
-            body:JSON.stringify({feed:[bookmarkWithParentThatExist]})
+            body:JSON.stringify({bookmarks:[bookmarkWithParentThatExist]})
         });
     });
     //Log in
@@ -167,7 +129,24 @@ test('Bookmark FocusFeedPost with PostView reply parent should display "View Par
     await page.getByTestId('login-password-input').getByRole('textbox').fill('password');
     // await page.getByRole('button').filter({visible:true}).getByText('Login',{exact:true}).click();
     await page.getByTestId('login-button').click();
-    await page.goto(`/profile/${handle1}`,{waitUntil:'networkidle'});
-    // await page.getByText(bookmarkText1).scrollIntoViewIfNeeded();
+    //View logged in User's Profile via interacting with the `UserButton`
+    await expect(page.getByTestId('userbutton-user-avatar')).toBeVisible();
+    // const userbuttonLoggedInAvatar = await page.getByTestId('userbutton-user-avatar').screenshot();
+    // await testInfo.attach('image showing UserButton with logged in User avatar', {
+    //     body: userbuttonLoggedInAvatar,
+    //     contentType: 'image/png',
+    // });
+    await page.getByTestId('userbutton').click();
+    await page.getByText('View Profile').click();
+    //Switch to the "Saved/Bookmark" tab
+    await expect(page.getByText('Saved')).toBeVisible();
+    // const savedTab = await page.getByText('Saved').screenshot();
+    // await testInfo.attach('image showing Saved tab on UserFocusModal', {
+    //     body: savedTab,
+    //     contentType: 'image/png',
+    // });
+    await page.getByText('Saved').click();
+    //Check that the displayed bookmark has the "View Parent of Reply" button visible
+    await page.getByText(bookmarkText1).scrollIntoViewIfNeeded();
     await expect(page.getByTestId('focusfeedpost-view-parent')).toBeVisible();
 })

--- a/tests/FocusFeedPost.spec.ts
+++ b/tests/FocusFeedPost.spec.ts
@@ -7,30 +7,42 @@ import { BookmarkView } from "@atproto/api/dist/client/types/app/bsky/bookmark/d
 
 let handle1:string = 'tester.da.playwright';
 let handle2:string = 'i.am.very.secretive';
+let handle3:string = 'handle.seeker';
 let displayName1:string = 'I AM A TESTER';
 let displayName2:string = `tester don't play that`;
+let displayName3:string = `Book Mark`;
 let profile1 = await CreateUserProfile(handle1,displayName2);
 let profile2 = await CreateUserProfile(handle2);
 let post1:AppBskyFeedGetPostThread.OutputSchema;
-let postWithParentThatExists:FeedViewPost;
+let postWithoutParent:FeedViewPost;
+let postWithPostViewParent:FeedViewPost;
 let postWithNotFoundPostParent:FeedViewPost;
-let bookmarkWithParentThatExist:BookmarkView;
+let bookmarkWithPostViewParent:BookmarkView;
+let bookmarkWithNotFoundPostParent:BookmarkView;
 let postText1 = "Lorem ipsum dipsum, dimsum, mmm I'm hungry";
 let postText2 = 'I am replying to a post. My parent has not been deleted.';
 let postText3 = 'I am replying to a post. My parent has been deleted.😢';
+let postText4 = 'I have no parent!!';
 let bookmarkText1 = 'You bookmarked me!🔖';
+let bookmarkText2 = 'Request the User Profile of my Parent!🔖';
 let currentDateTime = new Date();
 await CreateThreadViewPost(handle1,postText1,{activate:true,type:'img'},false,{activate:true,images:true,type:'ext_gif'},'I AM A TESTER').then(res =>{
     post1 = {thread:res as $Typed<ThreadViewPost>}
 })
+await CreateFeedViewPost(handle1,postText4,undefined,displayName1,currentDateTime,undefined,"None").then(res => {
+    postWithoutParent = res;
+})
 await CreateFeedViewPost(handle1,postText2,undefined,displayName1,currentDateTime,undefined,"PostView").then(res => {
-    postWithParentThatExists = res;
+    postWithPostViewParent = res;
 })
 await CreateFeedViewPost(handle1,postText3,undefined,displayName1,currentDateTime,undefined,"NotFoundPost").then(res => {
     postWithNotFoundPostParent = res;
 })
 await CreateBookmarkView(handle1,bookmarkText1,displayName1,currentDateTime,"PostView").then(res => {
-    bookmarkWithParentThatExist = res;
+    bookmarkWithPostViewParent = res;
+})
+await CreateBookmarkView(handle3,bookmarkText2,displayName3,currentDateTime,"NotFoundPost").then(res => {
+    bookmarkWithNotFoundPostParent = res;
 })
 
 test.beforeEach(async ({ context }) => {
@@ -50,7 +62,7 @@ test.beforeEach(async ({ context }) => {
     // });
 })
 
-test('FocusFeedPost with valid reply parent should display "View Parent of Reply" button', async ({context, page}) => {
+test('FocusFeedPost WITHOUT a parent Post SHOULD NOT display "View Parent of Reply" button', async ({context, page}) => {
     await page.route(/app.bsky.actor.getProfile/, route => {
         route.fulfill({
             status: 200,
@@ -62,7 +74,28 @@ test('FocusFeedPost with valid reply parent should display "View Parent of Reply
         route.fulfill({
             status: 200,
             headers: { 'Content-Type': 'application/json' },
-            body:JSON.stringify({feed:[postWithParentThatExists]})
+            body:JSON.stringify({feed:[postWithoutParent]})
+        });
+    });
+    await page.goto(`/profile/${handle1}`,{waitUntil:'networkidle'});
+    // await expect(page).toHaveTitle(`${displayName2}'s Account | moongate`);
+    await page.getByText(postText4).scrollIntoViewIfNeeded();
+    await expect(page.getByTestId('focusfeedpost-view-parent')).toBeHidden();
+})
+
+test('FocusFeedPost WITH `PostView` parent Post SHOULD display "View Parent of Reply" button', async ({context, page}) => {
+    await page.route(/app.bsky.actor.getProfile/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(profile1)
+        });
+    });
+    await page.route(/app.bsky.feed.getAuthorFeed/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify({feed:[postWithPostViewParent]})
         });
     });
     await page.goto(`/profile/${handle1}`,{waitUntil:'networkidle'});
@@ -71,7 +104,7 @@ test('FocusFeedPost with valid reply parent should display "View Parent of Reply
     await expect(page.getByTestId('focusfeedpost-view-parent')).toBeVisible();
 })
 
-test('FocusFeedPost with NotFoundPost reply parent should not display "View Parent of Reply" button', async ({context, page}) => {
+test('FocusFeedPost WITH `NotFoundPost` parent Post SHOULD display "View Parent of Reply" button AND result in a call to the `app.bsky.actor.getProfile` API endpoint when clicked', async ({context, page}) => {
     await page.route(/app.bsky.actor.getProfile/, route => {
         route.fulfill({
             status: 200,
@@ -89,10 +122,16 @@ test('FocusFeedPost with NotFoundPost reply parent should not display "View Pare
     await page.goto(`/profile/${handle1}`,{waitUntil:'networkidle'});
     // await expect(page).toHaveTitle(`${displayName2}'s Account | moongate`);
     await page.getByText(postText3).scrollIntoViewIfNeeded();
-    await expect(page.getByTestId('focusfeedpost-view-parent')).toBeHidden();
+    await expect(page.getByTestId('focusfeedpost-view-parent')).toBeVisible();
+    //Check that network call to get User Profile of reply creator is made
+    const responsePromise = page.waitForResponse(/app.bsky.actor.getProfile/);
+    await page.getByTestId('focusfeedpost-view-parent').click()
+    const response = await responsePromise;
+    expect(response.status()).toEqual(200);
+    expect(await response.json()).toEqual(profile1);
 })
 
-test('Bookmarked FocusFeedPost with PostView reply parent should display "View Parent of Reply" button', async ({context, page},testInfo) => {
+test('Bookmarked FocusFeedPost WITH `PostView` parent Post SHOULD display "View Parent of Reply" button AND result in a call to the `app.bsky.actor.getProfile` API endpoint when clicked', async ({context, page},testInfo) => {
     let sessionResponse = CreateLoginSessionResponse(profile1.handle,profile1.did);
     await page.route(/com.atproto.server.createSession/, route => {
         route.fulfill({
@@ -119,7 +158,7 @@ test('Bookmarked FocusFeedPost with PostView reply parent should display "View P
         route.fulfill({
             status: 200,
             headers: { 'Content-Type': 'application/json' },
-            body:JSON.stringify({bookmarks:[bookmarkWithParentThatExist]})
+            body:JSON.stringify({bookmarks:[bookmarkWithPostViewParent]})
         });
     });
     //Log in
@@ -149,4 +188,64 @@ test('Bookmarked FocusFeedPost with PostView reply parent should display "View P
     //Check that the displayed bookmark has the "View Parent of Reply" button visible
     await page.getByText(bookmarkText1).scrollIntoViewIfNeeded();
     await expect(page.getByTestId('focusfeedpost-view-parent')).toBeVisible();
+    //Check that network call to get User Profile of reply creator is made
+    const responsePromise = page.waitForResponse(/app.bsky.actor.getProfile/);
+    await page.getByTestId('focusfeedpost-view-parent').click()
+    const response = await responsePromise;
+    expect(response.status()).toEqual(200);
+    expect(await response.json()).toEqual(profile1);
+})
+
+test('Bookmarked FocusFeedPost WITH `NotFoundPost` parent Post SHOULD display "View Parent of Reply" button AND result in a call to the `app.bsky.actor.getProfile` API endpoint when clicked', async ({context, page},testInfo) => {
+    let sessionResponse = CreateLoginSessionResponse(profile1.handle,profile1.did);
+    await page.route(/com.atproto.server.createSession/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(sessionResponse)
+        });
+    });
+    await page.route(/app.bsky.actor.getProfile/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(profile2)
+        });
+    });
+    await page.route(/app.bsky.feed.getAuthorFeed/, route => { //Author's main feed should return nothing...
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+        body:JSON.stringify({feed:[]})
+        });
+    });
+    await page.route(/app.bsky.bookmark.getBookmarks/, route => { //..only the Saved/Bookmark feed should return content
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify({bookmarks:[bookmarkWithNotFoundPostParent]})
+        });
+    });
+    //Log in
+    await page.goto(`/login`,{waitUntil:'networkidle'});
+    await page.getByTestId('login-to-account-button').click();
+    await page.getByTestId('login-username-input').getByRole('textbox').fill('username');
+    await page.getByTestId('login-password-input').getByRole('textbox').fill('password');
+    await page.getByTestId('login-button').click();
+    //View logged in User's Profile via interacting with the `UserButton`
+    await expect(page.getByTestId('userbutton-user-avatar')).toBeVisible();
+    await page.getByTestId('userbutton').click();
+    await page.getByText('View Profile').click();
+    //Switch to the "Saved/Bookmark" tab
+    await expect(page.getByText('Saved')).toBeVisible();
+    await page.getByText('Saved').click();
+    //Check that the displayed bookmark has the "View Parent of Reply" button visible
+    await page.getByText(bookmarkText2).scrollIntoViewIfNeeded();
+    await expect(page.getByTestId('focusfeedpost-view-parent')).toBeVisible();
+    //Check that network call to get User Profile of reply creator is made
+    const responsePromise = page.waitForResponse(/app.bsky.actor.getProfile/);
+    await page.getByTestId('focusfeedpost-view-parent').click()
+    const response = await responsePromise;
+    expect(response.status()).toEqual(200);
+    expect(await response.json()).toEqual(profile2);
 })

--- a/tests/FocusFeedPost.spec.ts
+++ b/tests/FocusFeedPost.spec.ts
@@ -1,7 +1,8 @@
 import test, { expect } from "@playwright/test";
-import { CreateFeedViewPost, CreateThreadViewPost, CreateUserProfile } from "../src/fake-data/DataFactory";
+import { CreateBookmarkView, CreateFeedViewPost, CreateThreadViewPost, CreateUserProfile } from "../src/fake-data/DataFactory";
 import { $Typed, AppBskyFeedGetPostThread } from "@atproto/api";
 import { FeedViewPost, ThreadViewPost } from "@atproto/api/dist/client/types/app/bsky/feed/defs";
+import { BookmarkView } from "@atproto/api/dist/client/types/app/bsky/bookmark/defs";
 
 
 let handle1:string = 'tester.da.playwright';
@@ -13,9 +14,11 @@ let profile2 = await CreateUserProfile(handle2);
 let post1:AppBskyFeedGetPostThread.OutputSchema;
 let postWithParentThatExists:FeedViewPost;
 let postWithNotFoundPostParent:FeedViewPost;
+let bookmarkWithParentThatExist:BookmarkView;
 let postText1 = "Lorem ipsum dipsum, dimsum, mmm I'm hungry";
 let postText2 = 'I am replying to a post. My parent has not been deleted.';
 let postText3 = 'I am replying to a post. My parent has been deleted.😢';
+let bookmarkText1 = 'You bookmarked me!🔖';
 let currentDateTime = new Date();
 await CreateThreadViewPost(handle1,postText1,{activate:true,type:'img'},false,{activate:true,images:true,type:'ext_gif'},'I AM A TESTER').then(res =>{
     post1 = {thread:res as $Typed<ThreadViewPost>}
@@ -25,6 +28,9 @@ await CreateFeedViewPost(handle1,postText2,undefined,displayName1,currentDateTim
 })
 await CreateFeedViewPost(handle1,postText3,undefined,displayName1,currentDateTime,undefined,"NotFoundPost").then(res => {
     postWithNotFoundPostParent = res;
+})
+await CreateBookmarkView(handle1,bookmarkText1,displayName1,currentDateTime).then(res => {
+    bookmarkWithParentThatExist = res;
 })
 
 test.beforeEach(async ({ context }) => {
@@ -42,6 +48,51 @@ test.beforeEach(async ({ context }) => {
     //         body:JSON.stringify({feed:[post2]})
     //     });
     // });
+    //Intercept any attempt to log in and return dummy session data
+    await context.route(/com.atproto.server.createSession/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(
+                {
+                    did: "did:plc:test-session",
+                    didDoc: {
+                        "@context": [
+                            "https://www.w3.org/ns/did/v1",
+                            "https://w3id.org/security/multikey/v1",
+                            "https://w3id.org/security/suites/secp256k1-2019/v1"
+                        ],
+                        id: "did:plc:test-session",
+                        alsoKnownAs: [
+                            "at://test-session.bsky.social"
+                        ],
+                        verificationMethod: [
+                            {
+                                id: "did:plc:test-session#atproto",
+                                type: "Multikey",
+                                controller: "did:plc:test-session",
+                                publicKeyMultibase: "zQ3shkYUSJxz7PmCaGznbNR5oMCLKsjC7foCUVLVhxhioa5fa"
+                            }
+                        ],
+                        service: [
+                            {
+                                id: "#atproto_pds",
+                                type: "AtprotoPersonalDataServer",
+                                serviceEndpoint: "https://hollowfoot.us-west.host.bsky.network"
+                            }
+                        ]
+                    },
+                    handle: "test-session.bsky.social",
+                    email: "testSession@mail.com",
+                    emailConfirmed: true,
+                    emailAuthFactor: false,
+                    accessJwt: "testAccessJwt",
+                    refreshJwt: "testRefreshJwt",
+                    active: true
+                }
+            )
+        });
+    });
 })
 
 test('FocusFeedPost with valid reply parent should display "View Parent of Reply" button', async ({context, page}) => {
@@ -84,4 +135,39 @@ test('FocusFeedPost with NotFoundPost reply parent should not display "View Pare
     // await expect(page).toHaveTitle(`${displayName2}'s Account | moongate`);
     await page.getByText(postText3).scrollIntoViewIfNeeded();
     await expect(page.getByTestId('focusfeedpost-view-parent')).toBeHidden();
+})
+
+test('Bookmark FocusFeedPost with PostView reply parent should display "View Parent of Reply" button', async ({context, page}) => {
+    // console.log(JSON.stringify(bookmarkWithParentThatExist));
+    await page.route(/app.bsky.actor.getProfile/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(profile1)
+        });
+    });
+    await page.route(/app.bsky.feed.getAuthorFeed/, route => { //Author's main feed should return nothing...
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+        body:JSON.stringify({feed:[]})
+        });
+    });
+    await page.route(/app.bsky.bookmark.getBookmarks/, route => { //..only the Saved/Bookmark feed should return content
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify({feed:[bookmarkWithParentThatExist]})
+        });
+    });
+    //Log in
+    await page.goto(`/login`,{waitUntil:'networkidle'});
+    await page.getByTestId('login-to-account-button').click();
+    await page.getByTestId('login-username-input').getByRole('textbox').fill('username');
+    await page.getByTestId('login-password-input').getByRole('textbox').fill('password');
+    // await page.getByRole('button').filter({visible:true}).getByText('Login',{exact:true}).click();
+    await page.getByTestId('login-button').click();
+    await page.goto(`/profile/${handle1}`,{waitUntil:'networkidle'});
+    // await page.getByText(bookmarkText1).scrollIntoViewIfNeeded();
+    await expect(page.getByTestId('focusfeedpost-view-parent')).toBeVisible();
 })

--- a/tests/FocusFeedPost.spec.ts
+++ b/tests/FocusFeedPost.spec.ts
@@ -29,7 +29,7 @@ await CreateFeedViewPost(handle1,postText2,undefined,displayName1,currentDateTim
 await CreateFeedViewPost(handle1,postText3,undefined,displayName1,currentDateTime,undefined,"NotFoundPost").then(res => {
     postWithNotFoundPostParent = res;
 })
-await CreateBookmarkView(handle1,bookmarkText1,displayName1,currentDateTime).then(res => {
+await CreateBookmarkView(handle1,bookmarkText1,displayName1,currentDateTime,"PostView").then(res => {
     bookmarkWithParentThatExist = res;
 })
 


### PR DESCRIPTION
- Fixed issue in `FocusFeedPost` where clicking on "View Parent of Post" button to display a Post's parent would not work.
- Updated `DataFactory` so that has new methods for creating dummy `PostView`, `NotFoundPost` and `BookmarkView` objects, as well as the ability to create a dummy `Session` object for mocking a login response. 
- Created playwright tests (`FocusFeedPost.spec.ts`) to ensure expected behavior displaying and handling click of "View Parent of Post" button.
- Updated app version to 0.8.7.