### PR TITLE
Bugfix #267 - Fix `PostFocusModal` shortcut key confilcts

### DIFF
--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -330,28 +330,13 @@ export default defineComponent({
          * @param e Key down event.
          */
         onKeyboardShorcutEntered(e:KeyboardEvent){
-            if(e.key == 'ArrowLeft' && !e.repeat){
+            if(e.key == 'ArrowLeft' && !e.altKey && !e.repeat){
                 this.decreaseCurrentMediaIndex();
             }
-            else if(e.key == 'ArrowRight' && !e.repeat){
+            else if(e.key == 'ArrowRight' && !e.altKey && !e.repeat){
                 this.increaseCurrentMediaIndex();
             }
-            if(e.key == 'ArrowLeft' && e.altKey && !e.repeat){
-                this.decreaseThreadNavIndex();
-            }
-            else if(e.key == 'ArrowRight' && e.altKey && !e.repeat){
-                this.increaseThreadNavIndex();
-            }
             // else if(!e.repeat) console.log('Other key pressed: '+e.key);
-        },
-        /**
-         * Method that adds support for navigating through the modal navigation history
-         * using the Mouse "Browser Back" and "Browser Forward" buttons.
-         * @param e The MouseEvent fired.
-         */
-        onMouseShortcutEntered(e:MouseEvent){
-            if(e.button == 3) this.decreaseThreadNavIndex();
-            else if (e.button == 4) this.increaseThreadNavIndex();
         },
         /**
          * Method used to retrieve the Post/Post thread data via the Bluesky
@@ -756,8 +741,10 @@ export default defineComponent({
         },
         /**Updates the displayed post image when media index in route changes. */
         clickedMediaIndex(newIndex:number,oldIndex:number){
-            if(typeof newIndex != 'undefined' && newIndex != oldIndex && !this.$router.currentRoute.value.path.includes('/download'))
+            if(typeof newIndex != 'undefined' && newIndex != oldIndex && !this.$router.currentRoute.value.path.includes('/download')){
                 this.currentMediaIndex = newIndex;
+                document.title = this.getFocusPostTitle;
+            }
         }
     },
     beforeRouteEnter(to, from, next){
@@ -789,7 +776,6 @@ export default defineComponent({
     mounted(){
         //Add keyboard+mouse shortcut listener
         this.$el.addEventListener('keydown', this.onKeyboardShorcutEntered);
-        this.$el.addEventListener('mouseup', this.onMouseShortcutEntered);
         (this.$el as HTMLElement).focus();
         document.title = `Loading Post data... | moongate`
     },
@@ -797,7 +783,6 @@ export default defineComponent({
         console.log('Closing PostFocusModal...');
         //Remove keyboard+mouse shortcut listener
         this.$el.removeEventListener('keydown', this.onKeyboardShorcutEntered);
-        this.$el.removeEventListener('mouseup', this.onMouseShortcutEntered);
         AppState.handleFocusOnComponentClose();
     },
 })

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -65,21 +65,20 @@ function keepDefaultView(to, from) {
 }
 
 export const routes:RouteRecordRaw[] = [
-    { path:'/', meta:{title:'Home | moongate'},component: Sidebar },
-    { path:'/login', meta:{title:'Login | moongate'}, components:{ user_prompt:LoginModal }, beforeEnter:[keepDefaultView] },
-    { path:'/about', meta:{title:'About | moongate'}, components:{ modal:AboutAppModal }, beforeEnter:[keepDefaultView] },
-    { path:'/settings', meta:{title: 'Settings | moongate'}, components:{ modal:SettingsPanel }, beforeEnter:[keepDefaultView] },
-    { path:'/profile/:handle', components:{ modal:UserFocusModal }, beforeEnter:[keepDefaultView], props:true },
-    { path:'/profile/:handle/post/:postDid', components:{ modal2:PostFocusModal }, beforeEnter:[keepDefaultView], props:true },
+    { path:'/', name:'home', meta:{title:'Home | moongate'},component: Sidebar },
+    { path:'/login', name:'login', meta:{title:'Login | moongate'}, components:{ user_prompt:LoginModal }, beforeEnter:[keepDefaultView] },
+    { path:'/about', name:'about', meta:{title:'About | moongate'}, components:{ modal:AboutAppModal }, beforeEnter:[keepDefaultView] },
+    { path:'/settings', name:'settings', meta:{title: 'Settings | moongate'}, components:{ modal:SettingsPanel }, beforeEnter:[keepDefaultView] },
+    { path:'/profile/:handle', name:'userfocusmodal', components:{ modal:UserFocusModal }, beforeEnter:[keepDefaultView], props:true },
+    { path:'/profile/:handle/post/:postDid', name:'postfocusmodal', components:{ modal2:PostFocusModal }, beforeEnter:[keepDefaultView], props:true },
     // { path:'/profile/:handle/post/:postDid/:clickedMediaIndex', components:{ modal:PostFocusModal }, beforeEnter:[keepDefaultView], props:true, name:'postWithMedia'},
-    { path:'/profile/:handle/post/:postDid/:clickedMediaIndex', components:{ modal2:PostFocusModal }, beforeEnter:[keepDefaultView],
-    props: route=> ({clickedMediaIndex: parseInt(route.params.clickedMediaIndex), handle: route.params.handle, postDid: route.params.postDid}),
-    name:'postWithMedia'},
-    { path:'/profile/:handle/post/:postId/download', components:{ user_prompt:SaveMediaModal }, beforeEnter:[keepDefaultView], props:true },
+    { path:'/profile/:handle/post/:postDid/:clickedMediaIndex', name:'postfocusmodal with mediaindex', components:{ modal2:PostFocusModal }, beforeEnter:[keepDefaultView],
+    props: route=> ({clickedMediaIndex: parseInt(route.params.clickedMediaIndex), handle: route.params.handle, postDid: route.params.postDid})},
+    { path:'/profile/:handle/post/:postId/download', name:'savemediamodal direct', components:{ user_prompt:SaveMediaModal }, beforeEnter:[keepDefaultView], props:true },
     { path:'/profile/:handle/post/:postId/:clickedMediaIndex/download', name:'saving media', components:{ user_prompt:SaveMediaModal }, beforeEnter:[keepDefaultView], props:true },
-    { path:'/create/feed/', meta:{title:'Selecting Feed Type | moongate'}, components:{ modal:FeedEditModal }, beforeEnter:[keepDefaultView], props:true },
+    { path:'/create/feed/', name:'create feed', meta:{title:'Selecting Feed Type | moongate'}, components:{ modal:FeedEditModal }, beforeEnter:[keepDefaultView], props:true },
     { path:'/create/feed/:feedType', name:'feed type selected', components:{ modal:FeedEditModal }, beforeEnter:[keepDefaultView], props:true },
     { path:'/create/feed/:feedType/:summary', name:'create feed summary', components:{ modal:FeedEditModal }, beforeEnter:[keepDefaultView], props:true },
-    { path:'/create/post/', components:{ user_prompt:CreatePost }, beforeEnter:[keepDefaultView], props:true },
+    { path:'/create/post/', name:'create post', components:{ user_prompt:CreatePost }, beforeEnter:[keepDefaultView], props:true },
     { path: '/:pathMatch(.*)*', redirect:'/' }, //catches all invalid routes
 ]


### PR DESCRIPTION
- Fixed the conflicting `Arrow Key` and `ALT + Arrow Key` shortcuts used to change the media index and navigate the browser history that occured in `PostFocusModal`.
- Removed the "Mouse Shortcut` that used to be used to navigate the custom thread history solution that had been created. It is no longer needed now that routing is used.
- Added `name` values to all the routes defined in `router.ts`.