### PR TITLE
Feature #280 - Add `BroadcastChannel` interface to app

### DIFF
--- a/src/Sidebar.vue
+++ b/src/Sidebar.vue
@@ -144,7 +144,7 @@ import { FeedEnums } from "./enums/FeedEnums";
 import FeedEditModal from "./components/Feed/FeedEditModal.vue";
 import UserFocusModal from "./components/User/UserFocusModal.vue";
 import { OptionsMenuState } from "./state/OptionsMenuState.vue";
-import { GetBrowsingAgent } from "./lib/api.vue";
+import { ResumeAuthSession, GetBrowsingAgent } from "./lib/api.vue";
 import { SavedFeeds } from "./lib/db/local_db";
 import { AccountPeekState } from "./state/AccountPeekState.vue";
 import FeedButton from "./components/Navbar/FeedButton.vue";
@@ -165,6 +165,7 @@ import AboutAppModal from "./components/Settings/AboutAppModal.vue";
 import UserButton from "./components/Navbar/UserButton.vue";
 import { isBroadcastObject } from "./types/BroadcastChannelTypes";
 import { BroadcastChannelTarget } from "./types/BroadcastChannelTypes";
+import { LoginState } from "./interfaces/AccountInterfaces";
 
 
     export default defineComponent({
@@ -434,6 +435,15 @@ import { BroadcastChannelTarget } from "./types/BroadcastChannelTypes";
                                 console.log('This message is for updating the "App Settings" state.');
                                 AppSettingsState.Settings = event.data.data;
                                 AppState.updateAppStateLoginValues();
+                                break;
+                            case BroadcastChannelTarget.LoginState:
+                                //Update App Settings in other tabs/windows, but DO NOT save change to disk
+                                console.log('This message is for updating the "Authorized Login" state.');
+                                console.log(event.data.data);
+                                console.log(AppSettingsState.Settings.savedAccountState.state);
+                                if(AppSettingsState.Settings.savedAccountState.state == LoginState.Authorized && typeof event.data.data == 'undefined') {console.log('this will be a logout action'); } //logout
+                                else if(typeof event.data.data != 'undefined') {console.log('this will sync the auth login state'); ResumeAuthSession(event.data.data);}
+                                else console.log('this will have been syncing guest browsing')
                                 break;
                             default:
                                 break;

--- a/src/Sidebar.vue
+++ b/src/Sidebar.vue
@@ -418,7 +418,11 @@ import { BroadcastChannelTarget } from "./types/BroadcastChannelTypes";
                     //WIP
                     if(isBroadcastObject(event.data)){
                         console.log('This message contains a BroadcastObject object')
-                        if(event.data.target == BroadcastChannelTarget.FeedColumn) console.log('This message is for updating the FeedColumn state.');
+                        if(event.data.target == BroadcastChannelTarget.FeedColumn){
+                            //Update FeedList in other tabs/windows, but DO NOT save change to disk
+                            console.log('This message is for updating the FeedColumn state.');
+                            FeedState.FeedList = event.data.data;
+                        }
                     }
                         console.log(event);
                 }

--- a/src/Sidebar.vue
+++ b/src/Sidebar.vue
@@ -163,6 +163,8 @@ import FeedOrderModal from "./components/Feed/FeedOrderModal.vue";
 import AppLogo from "./components/SVG/AppLogo.vue";
 import AboutAppModal from "./components/Settings/AboutAppModal.vue";
 import UserButton from "./components/Navbar/UserButton.vue";
+import { isBroadcastObject } from "./types/BroadcastChannelTypes";
+import { BroadcastChannelTarget } from "./types/BroadcastChannelTypes";
 
 
     export default defineComponent({
@@ -407,8 +409,23 @@ import UserButton from "./components/Navbar/UserButton.vue";
                     toast.add({summary:'Error', detail:`${err}`, severity:'error', group:'tr', life:3000})
                 });
             },
+            /**
+             * Method that sets up the listener actions for the `BroadcastChannel` used by the
+             * application.
+             */
+            setupBroadcastChannel(){
+                AppState.moongateBroadcastChannel.onmessage = (event) => {
+                    //WIP
+                    if(isBroadcastObject(event.data)){
+                        console.log('This message contains a BroadcastObject object')
+                        if(event.data.target == BroadcastChannelTarget.FeedColumn) console.log('This message is for updating the FeedColumn state.');
+                    }
+                        console.log(event);
+                }
+            },
             async appStartupProcedure(){
                 await this.setUpListeners();
+                this.setupBroadcastChannel();
                 await this.loadAppConfig();
                 if(isTauri()) invoke('show_main_window');//unhide main window and focus it via Rust
             },

--- a/src/Sidebar.vue
+++ b/src/Sidebar.vue
@@ -433,6 +433,7 @@ import { BroadcastChannelTarget } from "./types/BroadcastChannelTypes";
                                 //Update App Settings in other tabs/windows, but DO NOT save change to disk
                                 console.log('This message is for updating the "App Settings" state.');
                                 AppSettingsState.Settings = event.data.data;
+                                AppState.updateAppStateLoginValues();
                                 break;
                             default:
                                 break;

--- a/src/Sidebar.vue
+++ b/src/Sidebar.vue
@@ -418,13 +418,27 @@ import { BroadcastChannelTarget } from "./types/BroadcastChannelTypes";
                     //WIP
                     if(isBroadcastObject(event.data)){
                         console.log('This message contains a BroadcastObject object')
-                        if(event.data.target == BroadcastChannelTarget.FeedColumn){
-                            //Update FeedList in other tabs/windows, but DO NOT save change to disk
-                            console.log('This message is for updating the FeedColumn state.');
-                            FeedState.FeedList = event.data.data;
+                        // if(event.data.target == BroadcastChannelTarget.FeedColumn){
+                        //     //Update FeedList in other tabs/windows, but DO NOT save change to disk
+                        //     console.log('This message is for updating the FeedColumn state.');
+                        //     FeedState.FeedList = event.data.data;
+                        // }
+                        switch (event.data.target) {
+                            case BroadcastChannelTarget.FeedColumn:
+                                //Update FeedList in other tabs/windows, but DO NOT save change to disk
+                                console.log('This message is for updating the FeedColumn state.');
+                                FeedState.FeedList = event.data.data;
+                                break;
+                            case BroadcastChannelTarget.AppSettings:
+                                //Update App Settings in other tabs/windows, but DO NOT save change to disk
+                                console.log('This message is for updating the "App Settings" state.');
+                                AppSettingsState.Settings = event.data.data;
+                                break;
+                            default:
+                                break;
                         }
                     }
-                        console.log(event);
+                    console.log(event);
                 }
             },
             async appStartupProcedure(){

--- a/src/Sidebar.vue
+++ b/src/Sidebar.vue
@@ -119,7 +119,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { FeedState, AddFeedToList, OLDcreateFeedDescription, AddSavedFeed, LoadFeedPostsAsync, SaveFeedChanges } from "./state/FeedList.vue";
+import { FeedState, AddFeedToList, OLDcreateFeedDescription, AddSavedFeed, LoadFeedPostsAsync, SaveFeedChanges, RefreshAllFeeds } from "./state/FeedList.vue";
 import * as PostEnums from "./enums/PostEnums";
 import { postDetails } from "./state/PostDetails.vue";
 import { AppState, toast } from "./state/AppState.vue";
@@ -434,15 +434,17 @@ import { LoginState } from "./interfaces/AccountInterfaces";
                                 //Update App Settings in other tabs/windows, but DO NOT save change to disk
                                 console.log('This message is for updating the "App Settings" state.');
                                 AppSettingsState.Settings = event.data.data;
+                                //Set current account PFP after app setting sync
+                                if(AppSettingsState.Settings.savedAccountState.currentAccount>-1 && AppSettingsState.Settings.savedAccountState.accounts.length>0){
+                                    AppState.currentPFP = AppSettingsState.Settings.savedAccountState.accounts[AppSettingsState.Settings.savedAccountState.currentAccount].avatar;
+                                }
+                                //Sync login state
                                 AppState.updateAppStateLoginValues();
                                 break;
                             case BroadcastChannelTarget.LoginState:
-                                //Update App Settings in other tabs/windows, but DO NOT save change to disk
                                 console.log('This message is for updating the "Authorized Login" state.');
-                                console.log(event.data.data);
-                                console.log(AppSettingsState.Settings.savedAccountState.state);
-                                if(AppSettingsState.Settings.savedAccountState.state == LoginState.Authorized && typeof event.data.data == 'undefined') {console.log('this will be a logout action'); } //logout
-                                else if(typeof event.data.data != 'undefined') {console.log('this will sync the auth login state'); ResumeAuthSession(event.data.data);}
+                                if(AppSettingsState.Settings.savedAccountState.state == LoginState.Authorized && typeof event.data.data == 'undefined') {console.log('this will be a logout action'); AppState.UpdateAppStateAfterLogout(); } //logout
+                                else if(typeof event.data.data != 'undefined') {console.log('this will sync the auth login state'); ResumeAuthSession(event.data.data); RefreshAllFeeds();}
                                 else console.log('this will have been syncing guest browsing')
                                 break;
                             default:

--- a/src/components/Feed/FeedColumn.vue
+++ b/src/components/Feed/FeedColumn.vue
@@ -248,6 +248,7 @@ import TrendingTopic from './TrendingTopic.vue';
 import { isOnMobileTouchscreen } from '../../helpers/states';
 import SquareButton from '../Utilities/SquareButton.vue';
 import { HandleAPIError } from '../../helpers/errors';
+import { BroadcastChannelTarget, BroadcastObject, toRawDeep } from '../../types/BroadcastChannelTypes';
 
 var colElement;
 
@@ -554,6 +555,11 @@ export default defineComponent({
                     // insert it at its new index
                     FeedState.FeedList.splice(FeedState.newFeedColumnIndex-1, 0, elRemoved);
                     SaveFeedChanges()//Save changes to disk.
+                    .then(()=>{
+                        //Sync FeedColumn order across app instances
+                        let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.FeedColumn, data:structuredClone(toRawDeep(FeedState.FeedList))};
+                        AppState.SendAppSyncMessage(feedSyncMessage);
+                    })
                     .catch(err => {
                         toast.add(HandleAPIError(err, 'Error updating Feed position'));
                     })

--- a/src/components/Feed/FeedEditModal.vue
+++ b/src/components/Feed/FeedEditModal.vue
@@ -676,7 +676,7 @@ export default defineComponent({
             .then(res => {
                 //Create the Feed
                 if(AppState.isCreatingFeed){
-                    AddFeedToList(res.description,res.data,res.cursor,res.seenAt,false);
+                    AddFeedToList(res.description,res.data,res.cursor,res.seenAt,false,true,true);
                     AppState.moongateBroadcastChannel.postMessage(`Created new feed for: ${res.description.feedHandle}.`)
                     this.closeModal();
                 }

--- a/src/components/Feed/FeedEditModal.vue
+++ b/src/components/Feed/FeedEditModal.vue
@@ -759,7 +759,7 @@ export default defineComponent({
                 // }
                 if(successes>0){
                     let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.FeedColumn, data:structuredClone(toRawDeep(FeedState.FeedList))};
-                    AppState.moongateBroadcastChannel.postMessage(feedSyncMessage);
+                    AppState.SendAppSyncMessage(feedSyncMessage);
                     setTimeout(() => {
                         this.closeModal();
                     }, 3000);

--- a/src/components/Feed/FeedEditModal.vue
+++ b/src/components/Feed/FeedEditModal.vue
@@ -315,6 +315,7 @@ import { IUserSearchResult } from '../../interfaces/UserInterfaces';
 import FilterBar from '../Utilities/FilterBar.vue';
 import { PropType } from 'vue';
 import ImageLoader from '../Utilities/ImageLoader.vue';
+import { BroadcastChannelTarget, BroadcastObject } from '../../types/BroadcastChannelTypes.ts';
 
 export default defineComponent({
     components:{
@@ -676,6 +677,7 @@ export default defineComponent({
                 //Create the Feed
                 if(AppState.isCreatingFeed){
                     AddFeedToList(res.description,res.data,res.cursor,res.seenAt,false);
+                    AppState.moongateBroadcastChannel.postMessage(`Created new feed for: ${res.description.feedHandle}.`)
                     this.closeModal();
                 }
                 else if(AppState.isUpdatingFeed){
@@ -725,6 +727,8 @@ export default defineComponent({
                                 attempted:true,
                                 success:true
                             };
+                            let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.FeedColumn, data:{description:res.description,data:res.data,cursor:res.cursor,seenAt:res.seenAt,isAwaitingFeedData:false}};
+                            AppState.moongateBroadcastChannel.postMessage(feedSyncMessage);
                             successes++;
                         }
                     })

--- a/src/components/Feed/FeedEditModal.vue
+++ b/src/components/Feed/FeedEditModal.vue
@@ -315,7 +315,7 @@ import { IUserSearchResult } from '../../interfaces/UserInterfaces';
 import FilterBar from '../Utilities/FilterBar.vue';
 import { PropType } from 'vue';
 import ImageLoader from '../Utilities/ImageLoader.vue';
-import { BroadcastChannelTarget, BroadcastObject } from '../../types/BroadcastChannelTypes.ts';
+import { BroadcastChannelTarget, BroadcastObject, toRawDeep } from '../../types/BroadcastChannelTypes.ts';
 
 export default defineComponent({
     components:{
@@ -727,8 +727,6 @@ export default defineComponent({
                                 attempted:true,
                                 success:true
                             };
-                            let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.FeedColumn, data:{description:res.description,data:res.data,cursor:res.cursor,seenAt:res.seenAt,isAwaitingFeedData:false}};
-                            AppState.moongateBroadcastChannel.postMessage(feedSyncMessage);
                             successes++;
                         }
                     })
@@ -760,6 +758,8 @@ export default defineComponent({
                 //     };
                 // }
                 if(successes>0){
+                    let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.FeedColumn, data:structuredClone(toRawDeep(FeedState.FeedList))};
+                    AppState.moongateBroadcastChannel.postMessage(feedSyncMessage);
                     setTimeout(() => {
                         this.closeModal();
                     }, 3000);

--- a/src/components/Login/LoginModal.vue
+++ b/src/components/Login/LoginModal.vue
@@ -164,14 +164,15 @@ import { AppState, toast, TrapFocus } from '../../state/AppState.vue';
 import { LoginBskyAccount } from '../../lib/api/Login.vue';
 import { HandleAPIError } from '../../helpers/errors';
 import { AccountPeekState } from '../../state/AccountPeekState.vue';
-import { FeedState, RefreshFeed } from '../../state/FeedList.vue';
-import { GetBrowsingAgent } from '../../lib/api.vue';
+import { RefreshAllFeeds } from '../../state/FeedList.vue';
+import { GetAuthSession, GetBrowsingAgent } from '../../lib/api.vue';
 import SquareButton from '../Utilities/SquareButton.vue';
 import { AppSettingsState } from '../../state/AppSettingsState.vue';
 import { ATPlatform, IAccount, LoginState } from '../../interfaces/AccountInterfaces';
 import RadioBarButton from '../Utilities/RadioBarButton.vue';
 import { GenerateUniqueID } from '../../helpers/generators';
 import ConfirmModal from '../Utilities/ConfirmModal.vue';
+import { BroadcastChannelTarget, BroadcastObject, toRawDeep } from '../../types/BroadcastChannelTypes';
 
 /**
  * Asks the User if they're sure they would like to delete the selected
@@ -233,7 +234,7 @@ export default defineComponent({
                 AppState.canBrowse = true;
                 AccountPeekState.lastMouseEvent = new MouseEvent('login');
                 AccountPeekState.profileData = {did:'',handle:''};
-                this.refreshFeeds();//Refresh feeds so we can get likes, blocks etc.
+                RefreshAllFeeds();//Refresh feeds so we can get likes, blocks etc.
                 toast.add({summary:"Login Success", detail:``,severity:'success',group:'tr',life:3000});
             })
             .catch(err => {
@@ -278,6 +279,10 @@ export default defineComponent({
                         AppSettingsState.Settings.savedAccountState.state = LoginState.Authorized;
                     }
                     AppSettingsState.saveSettingsToStore();
+                    //sync "login state"
+                    let currentSession = GetAuthSession();
+                    let authSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.LoginState, data:toRawDeep(currentSession)};
+                    AppState.SendAppSyncMessage(authSyncMessage);
                     this.closeModal();
                 })
                 .catch(err => {
@@ -394,17 +399,6 @@ export default defineComponent({
             if(window.history.state.back != null && (window.history.state.back.includes('/profile') || window.history.state.back.includes('/settings'))) this.$router.go(-1);
             else if(window.history.state.back == null) this.$router.push(`/`);
             else this.$router.push(`/`);
-        },
-        /**
-         * Method that refreshes all the displayed Feeds after the User logs in.
-         * Used to get the displayed elements to reflect the User Account's
-         * preferences/state (liked posts, blocked users, etc.).
-         */
-        refreshFeeds(){
-            FeedState.FeedList.forEach(feed => {
-                RefreshFeed(feed.description.feedId,new Date(),10);
-            });
-            console.log("Refreshed Feeds.");
         },
         /**
          * Switches between using the default Bluesky Account Provider or

--- a/src/components/Navbar/FeedButton.vue
+++ b/src/components/Navbar/FeedButton.vue
@@ -34,6 +34,7 @@ import { IOptionMenuItem, ItemType } from '../Utilities/OptionsMenu.vue';
 import { IFeedDescription } from '../../interfaces/FeedInterfaces';
 import { FeedEnums } from '../../enums/FeedEnums';
 import { router } from '../../main';
+import { BroadcastChannelTarget, BroadcastObject, toRawDeep } from '../../types/BroadcastChannelTypes';
 
 /**
  * Method that ensures that the target position the FeedColumn display wants to
@@ -62,7 +63,8 @@ function UpdateFeed(){
  */
 function DeleteFeed(){
     RemoveFeed(FeedState.selectedFeed);
-    // FeedState.isFeedOptionMenuVisible = false;
+    let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.FeedColumn, data:structuredClone(toRawDeep(FeedState.FeedList))};
+    AppState.moongateBroadcastChannel.postMessage(feedSyncMessage);
     OptionsMenuState.hideOptionMenu();
 }
 /**

--- a/src/components/Navbar/FeedButton.vue
+++ b/src/components/Navbar/FeedButton.vue
@@ -64,7 +64,7 @@ function UpdateFeed(){
 function DeleteFeed(){
     RemoveFeed(FeedState.selectedFeed);
     let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.FeedColumn, data:structuredClone(toRawDeep(FeedState.FeedList))};
-    AppState.moongateBroadcastChannel.postMessage(feedSyncMessage);
+    AppState.SendAppSyncMessage(feedSyncMessage);
     OptionsMenuState.hideOptionMenu();
 }
 /**

--- a/src/components/Navbar/UserButton.vue
+++ b/src/components/Navbar/UserButton.vue
@@ -27,7 +27,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { AppState, toast } from '../../state/AppState.vue';
-import { GetBrowsingAgent, LogoutAgent } from '../../lib/api.vue';
+import { LogoutAgent } from '../../lib/api.vue';
 import { IOptionMenuItem, ItemType } from '../Utilities/OptionsMenu.vue';
 import { OptionsMenuState } from '../../state/OptionsMenuState.vue';
 import { HandleAPIError } from '../../helpers/errors';
@@ -38,9 +38,6 @@ import MdiUserSwitch from '~icons/mdi/user-switch';
 import MingcuteExitDoorLine from '~icons/mingcute/exit-door-line';
 import { AccountPeekState } from '../../state/AccountPeekState.vue';
 import { AppSettingsState } from '../../state/AppSettingsState.vue';
-import { LoginState } from '../../interfaces/AccountInterfaces';
-import { FeedState, RefreshFeed } from '../../state/FeedList.vue';
-import { BroadcastChannelTarget, BroadcastObject } from '../../types/BroadcastChannelTypes';
 
 let optionsMenu:IOptionMenuItem[] = [
     {Icon:MingcuteProfileFill,Label:'View Profile',Action:displayCurrentUsersAccount,Type:ItemType.Option},
@@ -96,22 +93,7 @@ function confirmLogout(){
 async function logoutOfAccount(){
     await LogoutAgent()
     .then(() => {
-        AppState.canBrowse = AppState.isGuestBrowsing = AppState.isAuthBrowsing = false;
-        AppState.currentUsername = "Login Here";
-        AppSettingsState.Settings.savedAccountState = {
-            ...AppSettingsState.Settings.savedAccountState,
-            currentAccount:-1,
-            state:LoginState.Unset
-        }
-        AccountPeekState.lastMouseEvent = new MouseEvent('logout');
-        AccountPeekState.profileData = {did:'',handle:''};
-        //Send logout sync
-        let authSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.LoginState, data:undefined};
-        AppState.SendAppSyncMessage(authSyncMessage);
-        //Refresh displayed Feeds after logout
-        FeedState.FeedList.forEach(feed => {
-            RefreshFeed(feed.description.feedId,new Date(),10);
-        });
+        AppState.UpdateAppStateAfterLogout();
     })
     .catch(err => toast.add(HandleAPIError(err, 'Error logging out')));
 }

--- a/src/components/Navbar/UserButton.vue
+++ b/src/components/Navbar/UserButton.vue
@@ -40,6 +40,7 @@ import { AccountPeekState } from '../../state/AccountPeekState.vue';
 import { AppSettingsState } from '../../state/AppSettingsState.vue';
 import { LoginState } from '../../interfaces/AccountInterfaces';
 import { FeedState, RefreshFeed } from '../../state/FeedList.vue';
+import { BroadcastChannelTarget, BroadcastObject } from '../../types/BroadcastChannelTypes';
 
 let optionsMenu:IOptionMenuItem[] = [
     {Icon:MingcuteProfileFill,Label:'View Profile',Action:displayCurrentUsersAccount,Type:ItemType.Option},
@@ -104,6 +105,9 @@ async function logoutOfAccount(){
         }
         AccountPeekState.lastMouseEvent = new MouseEvent('logout');
         AccountPeekState.profileData = {did:'',handle:''};
+        //Send logout sync
+        let authSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.LoginState, data:undefined};
+        AppState.SendAppSyncMessage(authSyncMessage);
         //Refresh displayed Feeds after logout
         FeedState.FeedList.forEach(feed => {
             RefreshFeed(feed.description.feedId,new Date(),10);

--- a/src/components/Settings/AboutAppModal.vue
+++ b/src/components/Settings/AboutAppModal.vue
@@ -38,6 +38,18 @@
             <div class="flex flex-col overflow-y-auto pt-2">
                 <div class="px-4 text-xl font-semibold">Changelog:</div>
                 <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
+                    <div class="font-semibold">February 10th 2026</div>
+                    <ul class="list-disc list-inside h-full py-1 text-sm">
+                        <li>Updated app so that application state is synced between all open web-based application instances.
+                            <ul class="list-disc list-inside h-full text-sm">
+                                <li>Modifying the displayed Feed List is synced between instances.</li>
+                                <li>Modifying application settings is synced betweeen instances.</li>
+                                <li>Logging in/out or changing browsing modes is synced betweeen instances.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
+                <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
                     <div class="font-semibold">January 22nd 2026</div>
                     <ul class="list-disc list-inside h-full py-1 text-sm">
                         <li>Updated "View Parent of Post" button that is displayed on "reply posts".

--- a/src/components/Utilities/AvatarRound.vue
+++ b/src/components/Utilities/AvatarRound.vue
@@ -41,7 +41,7 @@ function CreateUserFeed(userDid:string,userHandle:string){
         name:''
     })
     .then(res => {
-        AddFeedToList(res.description,res.data,res.cursor,res.seenAt,false);
+        AddFeedToList(res.description,res.data,res.cursor,res.seenAt,false,true,true);
     })
     .catch(err => {
         toast.add({summary:'Error', detail:`${err}`, severity:'error', group:'tr', life:3000});

--- a/src/lib/api.vue
+++ b/src/lib/api.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 // src/lib/api.ts
-import { Agent, AtpAgentLoginOpts, ComAtprotoServerCreateSession, CredentialSession } from "@atproto/api";
+import { Agent, AtpAgentLoginOpts, AtpSessionData, ComAtprotoServerCreateSession, CredentialSession } from "@atproto/api";
 import { AppState } from '../state/AppState.vue';
 
 export default{
@@ -39,6 +39,23 @@ export function GetBrowsingAgent():Agent{
   else{
     return guestAgent;
   }
+}
+
+/**
+ * Method used to access `CredentialSession` object used for authorized
+ * access to Bluesky's API. Should only be used to sync the "login state"
+ * between app instances open in multiple tabs/windows.
+ */
+export function GetAuthSession():AtpSessionData|undefined{
+  return authSession.session;
+}
+
+/**
+ * Method used to resume an already authorized API session. Should on be used to sync
+ * the "login state" between app instances open in multiple tabs/windows.
+ */
+export function ResumeAuthSession(sessionData:AtpSessionData){
+  authSession.resumeSession(sessionData);
 }
 
 /**

--- a/src/state/AppSettingsState.vue
+++ b/src/state/AppSettingsState.vue
@@ -7,6 +7,7 @@ import { WebDBAppSettings, web_db } from '../lib/db/web_db';
 import { ATPlatform, LoginState } from '../interfaces/AccountInterfaces';
 import { AppState } from './AppState.vue';
 import { BroadcastChannelTarget, BroadcastObject, toRawDeep } from '../types/BroadcastChannelTypes';
+import { GetAuthSession } from '../lib/api.vue';
 
 export default{
     name:"AppSettingsState"
@@ -239,9 +240,13 @@ export const AppSettingsState = reactive({
             })
             .then(res => {
                 console.log(res);
-                //sync between tabs/windows on success
+                //sync "app settings" between tabs/windows on success
                 let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.AppSettings, data:toRawDeep(cs)};
                 AppState.SendAppSyncMessage(feedSyncMessage);
+                //sync "login state"
+                let currentSession = GetAuthSession();
+                let authSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.LoginState, data:toRawDeep(currentSession)};
+                AppState.SendAppSyncMessage(authSyncMessage);
             })
             .catch(err => {
                 console.log(`Error trying to save settings to IndexedDB`);

--- a/src/state/AppSettingsState.vue
+++ b/src/state/AppSettingsState.vue
@@ -6,6 +6,7 @@ import { isTauri } from '@tauri-apps/api/core';
 import { WebDBAppSettings, web_db } from '../lib/db/web_db';
 import { ATPlatform, LoginState } from '../interfaces/AccountInterfaces';
 import { AppState } from './AppState.vue';
+import { BroadcastChannelTarget, BroadcastObject, toRawDeep } from '../types/BroadcastChannelTypes';
 
 export default{
     name:"AppSettingsState"
@@ -236,9 +237,12 @@ export const AppSettingsState = reactive({
                 isHidingFollowing: cs.isHidingFollowing,
                 savedAccountState:JSON.stringify(cs.savedAccountState),
             })
-            // .then(res => {
-            //     console.log(res);
-            // })
+            .then(res => {
+                console.log(res);
+                //sync between tabs/windows on success
+                let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.AppSettings, data:toRawDeep(cs)};
+                AppState.SendAppSyncMessage(feedSyncMessage);
+            })
             .catch(err => {
                 console.log(`Error trying to save settings to IndexedDB`);
                 console.log(err);

--- a/src/state/AppSettingsState.vue
+++ b/src/state/AppSettingsState.vue
@@ -243,10 +243,6 @@ export const AppSettingsState = reactive({
                 //sync "app settings" between tabs/windows on success
                 let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.AppSettings, data:toRawDeep(cs)};
                 AppState.SendAppSyncMessage(feedSyncMessage);
-                //sync "login state"
-                let currentSession = GetAuthSession();
-                let authSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.LoginState, data:toRawDeep(currentSession)};
-                AppState.SendAppSyncMessage(authSyncMessage);
             })
             .catch(err => {
                 console.log(`Error trying to save settings to IndexedDB`);

--- a/src/state/AppState.vue
+++ b/src/state/AppState.vue
@@ -95,6 +95,8 @@ export default{
  * as theming, current user, etc.
  */
 export const AppState = reactive({
+    /**BroadcastChannel used to keep elements of applications in sync when using multiple tabs/windows. */
+    moongateBroadcastChannel: new BroadcastChannel('moongate_bc'),
     /**Is the app in Dark Mode. If false, the light theme is used. */
     isDarkMode: true,
     /**

--- a/src/state/AppState.vue
+++ b/src/state/AppState.vue
@@ -131,6 +131,32 @@ export const AppState = reactive({
         toast.add({summary:'Browsing', detail:'Viewing content as guest.', severity:'info', group:'tr', life:3000})
     },
     /**
+     * Method used to make sure the variables held in `AppState` for determining "Login Status"
+     * are up to date and match what is held in `AppSettingsState.Settings.savedAccountState`.
+     * This method should only need to be used when handling the "App Settings" `BroadcastChannel` message used
+     * to sync application states over multiple tabs/windows.
+     */
+    updateAppStateLoginValues(){
+        switch (AppSettingsState.Settings.savedAccountState.state) {
+            case LoginState.Authorized:
+                AppState.isAuthBrowsing = true;
+                AppState.isGuestBrowsing = false;
+                AppState.currentUsername = "Logged In";
+                AppState.canBrowse = true;
+                break;
+            case LoginState.Guest:
+                AppState.isAuthBrowsing = false;
+                AppState.isGuestBrowsing = true;
+                AppState.currentUsername = "Guest";
+                AppState.canBrowse = true;
+                break;
+            default://Unset - no browsing mode choice made
+                AppState.canBrowse = AppState.isGuestBrowsing = AppState.isAuthBrowsing = false;
+                AppState.currentUsername = "Login Here";
+                break;
+        }
+    },
+    /**
      * Is the user browsing Bluesky with a user account. NOTE: if this is
      * true, `isGuestBrowsing` must be false.
      */

--- a/src/state/AppState.vue
+++ b/src/state/AppState.vue
@@ -15,6 +15,7 @@ import { LoginState } from '../interfaces/AccountInterfaces';
 import { ProfileView, ProfileViewBasic, ProfileViewDetailed } from '@atproto/api/dist/client/types/app/bsky/actor/defs';
 import { FeedEnums } from '../enums/FeedEnums';
 import { router } from '../main';
+import { BroadcastObject } from '../types/BroadcastChannelTypes';
 
 export const toast = {
     add: (message) => ToastEventBus.emit('add', message),
@@ -97,6 +98,14 @@ export default{
 export const AppState = reactive({
     /**BroadcastChannel used to keep elements of applications in sync when using multiple tabs/windows. */
     moongateBroadcastChannel: new BroadcastChannel('moongate_bc'),
+    /**
+     * Method used to send messages used to sync the application state between tabs/windows
+     * via the `BroadcastChannel`.
+     * @param messagePayload The data to sync between tabs/windows.
+     */
+    SendAppSyncMessage(messagePayload:BroadcastObject){
+        this.moongateBroadcastChannel.postMessage(messagePayload);
+    },
     /**Is the app in Dark Mode. If false, the light theme is used. */
     isDarkMode: true,
     /**

--- a/src/state/AppState.vue
+++ b/src/state/AppState.vue
@@ -8,14 +8,15 @@ import { ViewImage } from '@atproto/api/dist/client/types/app/bsky/embed/images'
 import { UserFocusModalState } from './UserFocusModalState.vue';
 import { ViewExternal } from '@atproto/api/dist/client/types/app/bsky/embed/external';
 import { postDetails } from './PostDetails.vue';
-import { FeedState } from './FeedList.vue';
+import { FeedState, RefreshAllFeeds } from './FeedList.vue';
 import { FeedViewPost, PostView, ThreadViewPost } from '@atproto/api/dist/client/types/app/bsky/feed/defs';
 import { AppSettingsState } from './AppSettingsState.vue';
 import { LoginState } from '../interfaces/AccountInterfaces';
 import { ProfileView, ProfileViewBasic, ProfileViewDetailed } from '@atproto/api/dist/client/types/app/bsky/actor/defs';
 import { FeedEnums } from '../enums/FeedEnums';
 import { router } from '../main';
-import { BroadcastObject } from '../types/BroadcastChannelTypes';
+import { BroadcastChannelTarget, BroadcastObject } from '../types/BroadcastChannelTypes';
+import { AccountPeekState } from './AccountPeekState.vue';
 
 export const toast = {
     add: (message) => ToastEventBus.emit('add', message),
@@ -119,10 +120,10 @@ export const AppState = reactive({
      * Updates `AppSettingsState` and prints toast message.
      */
     browseAsGuest(){
-        AppState.isAuthBrowsing = false;
-        AppState.isGuestBrowsing = true;
-        AppState.currentUsername = "Guest";
-        AppState.canBrowse = true;
+        this.isAuthBrowsing = false;
+        this.isGuestBrowsing = true;
+        this.currentUsername = "Guest";
+        this.canBrowse = true;
         AppSettingsState.Settings.savedAccountState = {
             ...AppSettingsState.Settings.savedAccountState,
             currentAccount:-1,
@@ -139,22 +140,45 @@ export const AppState = reactive({
     updateAppStateLoginValues(){
         switch (AppSettingsState.Settings.savedAccountState.state) {
             case LoginState.Authorized:
-                AppState.isAuthBrowsing = true;
-                AppState.isGuestBrowsing = false;
-                AppState.currentUsername = "Logged In";
-                AppState.canBrowse = true;
+                this.isAuthBrowsing = true;
+                this.isGuestBrowsing = false;
+                this.currentUsername = "Logged In";
+                this.canBrowse = true;
                 break;
             case LoginState.Guest:
-                AppState.isAuthBrowsing = false;
-                AppState.isGuestBrowsing = true;
-                AppState.currentUsername = "Guest";
-                AppState.canBrowse = true;
+                this.isAuthBrowsing = false;
+                this.isGuestBrowsing = true;
+                this.currentUsername = "Guest";
+                this.canBrowse = true;
                 break;
             default://Unset - no browsing mode choice made
-                AppState.canBrowse = AppState.isGuestBrowsing = AppState.isAuthBrowsing = false;
-                AppState.currentUsername = "Login Here";
+                this.canBrowse = this.isGuestBrowsing = this.isAuthBrowsing = false;
+                this.currentUsername = "Login Here";
                 break;
         }
+    },
+    /**
+     * Method used to update the Application state after logging out of a
+     * guest or authorized account. Mainly used to update visual elements so
+     * they correctly reflect the new "logged out" state. Refreshes displayed
+     * Feeds as part of process. Syncs changes between app intances using
+     * `BroadcastChannel` as well.
+     */
+    UpdateAppStateAfterLogout(){
+        this.canBrowse = this.isGuestBrowsing = this.isAuthBrowsing = false;
+        this.currentUsername = "Login Here";
+        AppSettingsState.Settings.savedAccountState = {
+            ...AppSettingsState.Settings.savedAccountState,
+            currentAccount:-1,
+            state:LoginState.Unset
+        }
+        AccountPeekState.lastMouseEvent = new MouseEvent('logout');
+        AccountPeekState.profileData = {did:'',handle:''};
+        //Send logout sync
+        let authSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.LoginState, data:undefined};
+        AppState.SendAppSyncMessage(authSyncMessage);
+        //Refresh displayed Feeds after logout
+        RefreshAllFeeds();
     },
     /**
      * Is the user browsing Bluesky with a user account. NOTE: if this is

--- a/src/state/FeedList.vue
+++ b/src/state/FeedList.vue
@@ -808,6 +808,18 @@ export async function RefreshFeed(feedId:String, lastUpdate:Date, postsToGet:num
 }
 
 /**
+ * Method used to refresh all feeds displayed in the `FeedColumn` component. Intended
+ * to be used when logging into or out of an authorized account. Used to get the displayed
+ * elements to reflect the User Account's preferences/state (liked posts, blocked users, etc.).
+ * @param postsToGet The number of Posts to initially retrieve for each Feed.
+ */
+export async function RefreshAllFeeds(postsToGet:number=10){
+    FeedState.FeedList.forEach(feed => {
+        RefreshFeed(feed.description.feedId,new Date(),postsToGet);
+    });
+}
+
+/**
  * Method used to refresh the data held in a currently displayed Feed.
  * @param feedId The ID of the loaded Feed that you want to refresh.
  */

--- a/src/state/FeedList.vue
+++ b/src/state/FeedList.vue
@@ -16,6 +16,7 @@ import { TrendView } from '@atproto/api/dist/client/types/app/bsky/unspecced/def
 import { isTauri } from '@tauri-apps/api/core';
 import { stringifyFeedListData, updateSavedFeedsTable } from '../lib/db/local_db';
 import { clearIndexedDBSavedFeeds, Feed, web_db } from '../lib/db/web_db';
+import { BroadcastChannelTarget, BroadcastObject, toRawDeep } from '../types/BroadcastChannelTypes';
 
 //Code from Mulan at https://stackoverflow.com/a/27747377
 function dec2hex (dec: number) {
@@ -78,13 +79,16 @@ export const FeedState = reactive({
  * @param description Details about the Feed (type, DID source, etc.).
  * @param feed The Feed data returned by the Bluesky API.
  * @param cursor Cursor to use when attempting to paginate displayed Posts.
+ * @param seenAt Value used to indicate when the displayed Notifications were seen. Only used for Notification-type feeds.
  * @param awaitingData Indicates if the Feed is waiting for data to display. Using
  * the default value of true usually means the Feed is being added from the "Saved Feed"
  * database.
  * @param saveChanges Should the FeedList be saved to disk after Feed was added. Can be
  * used to postpone save until bulk add has finished.
+ * @param syncFeed Should a message be sent through `BroadcastChannel` to sync the FeedList
+ * in all open instances of the app in any tabs/windows.
  */
-export async function AddFeedToList(description:IFeedDescription, feed:FeedViewPost[]|Notification[]|TrendView[], cursor:string='', seenAt:string='', awaitingData:boolean=true, saveChanges:boolean=true){
+export async function AddFeedToList(description:IFeedDescription, feed:FeedViewPost[]|Notification[]|TrendView[], cursor:string='', seenAt:string='', awaitingData:boolean=true, saveChanges:boolean=true, syncFeed:boolean=false){
     /**Used to prevent duplicate Feeds from being created during a hot reload (or any other situation) */
     let isFeedDuplicate = FeedState.FeedList.find(feed => feed.description.feedId == description.feedId) != undefined;
     if(isFeedDuplicate){
@@ -101,6 +105,11 @@ export async function AddFeedToList(description:IFeedDescription, feed:FeedViewP
     });
     //Save changes when requested
     if(saveChanges) await SaveFeedChanges();
+    //Sync feeds between tabs/windows
+    if(syncFeed){
+        let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.FeedColumn, data:structuredClone(toRawDeep(FeedState.FeedList))};
+        AppState.moongateBroadcastChannel.postMessage(feedSyncMessage);
+    }
 }
 
 /**

--- a/src/state/FeedList.vue
+++ b/src/state/FeedList.vue
@@ -108,7 +108,7 @@ export async function AddFeedToList(description:IFeedDescription, feed:FeedViewP
     //Sync feeds between tabs/windows
     if(syncFeed){
         let feedSyncMessage:BroadcastObject = {target:BroadcastChannelTarget.FeedColumn, data:structuredClone(toRawDeep(FeedState.FeedList))};
-        AppState.moongateBroadcastChannel.postMessage(feedSyncMessage);
+        AppState.SendAppSyncMessage(feedSyncMessage);
     }
 }
 

--- a/src/types/BroadcastChannelTypes.ts
+++ b/src/types/BroadcastChannelTypes.ts
@@ -1,11 +1,13 @@
 import { toRaw } from "vue";
 import { IFeedListing } from "../interfaces/FeedInterfaces";
 import { IAppSettings } from "../interfaces/SettingsInterfaces";
+import { AtpSessionData } from '../../node_modules/@atproto/api/dist/types';
 
 /**Enum used to specify the target of a `BroadcastChannel` message. */
 export enum BroadcastChannelTarget{
     AppSettings = "app_settings",
     FeedColumn = "feed_column",
+    LoginState = "login_state",
 }
 
 /**Type used to describe the shape of data sent as part of the `BroadcastChannel` message. */
@@ -13,7 +15,7 @@ export type BroadcastObject = {
     target:BroadcastChannelTarget,
     // data:IAppSettings|IFeedListing,
     message?:string,
-} & (BroadcastAppSettingData | BroadcastFeedColumnData)
+} & (BroadcastAppSettingData | BroadcastFeedColumnData | BroadcastAuthStateData)
 
 /**Type used as part of discriminated union on {@link BroadcastObject} to describe the shape of "FeedColumn" data. */
 export type BroadcastFeedColumnData = {
@@ -25,6 +27,12 @@ export type BroadcastFeedColumnData = {
 export type BroadcastAppSettingData = {
     target:BroadcastChannelTarget.AppSettings,
     data:IAppSettings
+}
+
+/**Type used as part of discriminated union on {@link BroadcastObject} to describe the shape of "App Settings" data. */
+export type BroadcastAuthStateData = {
+    target:BroadcastChannelTarget.LoginState,
+    data:AtpSessionData|undefined
 }
 
 /**

--- a/src/types/BroadcastChannelTypes.ts
+++ b/src/types/BroadcastChannelTypes.ts
@@ -1,3 +1,4 @@
+import { toRaw } from "vue";
 import { IFeedListing } from "../interfaces/FeedInterfaces";
 import { IAppSettings } from "../interfaces/SettingsInterfaces";
 
@@ -17,7 +18,7 @@ export type BroadcastObject = {
 /**Type used as part of discriminated union on {@link BroadcastObject} to describe the shape of "FeedColumn" data. */
 export type BroadcastFeedColumnData = {
     target:BroadcastChannelTarget.FeedColumn,
-    data:IFeedListing
+    data:IFeedListing[]
 }
 
 /**Type used as part of discriminated union on {@link BroadcastObject} to describe the shape of "App Settings" data. */
@@ -33,4 +34,30 @@ export type BroadcastAppSettingData = {
  */
 export function isBroadcastObject(broadcastObject: BroadcastObject|MessageEvent<any>): broadcastObject is BroadcastObject{
     return (broadcastObject as BroadcastObject).target !== undefined;
+}
+
+/**
+ * Method used to prepare reactive proxy (from reactive state) to be turned into a `structuredClone`.
+ * Thanks to Jonas Schade at https://stackoverflow.com/a/77022014.
+ * @param observed The object to prepare.
+ * @returns Raw object from Vue-created proxy.
+ */
+export function toRawDeep<T>(observed: T): T {
+    const val = toRaw(observed);
+
+    // add any classes, that you want to support:
+    if (val instanceof Date) return val;
+
+    if (Array.isArray(val)) {
+        return val.map(toRawDeep) as T;
+    }
+
+    if (val === null) return null as T;
+
+    if (typeof val === 'object') {
+        const entries = Object.entries(val).map(([key, val]) => [key, toRawDeep(val)]);
+        return Object.fromEntries(entries);
+    }
+
+    return val;
 }

--- a/src/types/BroadcastChannelTypes.ts
+++ b/src/types/BroadcastChannelTypes.ts
@@ -1,0 +1,36 @@
+import { IFeedListing } from "../interfaces/FeedInterfaces";
+import { IAppSettings } from "../interfaces/SettingsInterfaces";
+
+/**Enum used to specify the target of a `BroadcastChannel` message. */
+export enum BroadcastChannelTarget{
+    AppSettings = "app_settings",
+    FeedColumn = "feed_column",
+}
+
+/**Type used to describe the shape of data sent as part of the `BroadcastChannel` message. */
+export type BroadcastObject = {
+    target:BroadcastChannelTarget,
+    // data:IAppSettings|IFeedListing,
+    message?:string,
+} & (BroadcastAppSettingData | BroadcastFeedColumnData)
+
+/**Type used as part of discriminated union on {@link BroadcastObject} to describe the shape of "FeedColumn" data. */
+export type BroadcastFeedColumnData = {
+    target:BroadcastChannelTarget.FeedColumn,
+    data:IFeedListing
+}
+
+/**Type used as part of discriminated union on {@link BroadcastObject} to describe the shape of "App Settings" data. */
+export type BroadcastAppSettingData = {
+    target:BroadcastChannelTarget.AppSettings,
+    data:IAppSettings
+}
+
+/**
+ * Type Predicate method used to narrow the type of an object passed through the `BroadcastChannel.postMessage()` method.
+ * @param broadcastObject The object to type check.
+ * @returns Boolean value indicating if the object is of the `IBroadcastObject` type or not.
+ */
+export function isBroadcastObject(broadcastObject: BroadcastObject|MessageEvent<any>): broadcastObject is BroadcastObject{
+    return (broadcastObject as BroadcastObject).target !== undefined;
+}


### PR DESCRIPTION
- Adds `BroadcastChannel` interface to app.
- Uses `BroadcastChannel` sync the application state between open web-based instances of the application when:
  - Modifying the collection of displayed Feeds
  - Modifying application settings such as color theme, hidden metrics, etc.
  - Logging in/out or changing browsing modes
- Adds new `BroadcastChannelTypes.ts` class/types file.
- Adds new helper methods and small refinements related to working with the `FeedList`.