### PR TITLE
Feature #279 - Delay `FeedColumn` loading when not at "Main View" route

### DIFF
--- a/src/Sidebar.vue
+++ b/src/Sidebar.vue
@@ -119,7 +119,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { FeedState, AddFeedToList, OLDcreateFeedDescription, AddSavedFeed, LoadFeedPostsAsync, SaveFeedChanges, RefreshAllFeeds } from "./state/FeedList.vue";
+import { FeedState, AddFeedToList, OLDcreateFeedDescription, AddSavedFeed, SaveFeedChanges, RefreshAllFeeds, LoadAllFeedPostsAsync } from "./state/FeedList.vue";
 import * as PostEnums from "./enums/PostEnums";
 import { postDetails } from "./state/PostDetails.vue";
 import { AppState, toast } from "./state/AppState.vue";
@@ -166,6 +166,7 @@ import UserButton from "./components/Navbar/UserButton.vue";
 import { isBroadcastObject } from "./types/BroadcastChannelTypes";
 import { BroadcastChannelTarget } from "./types/BroadcastChannelTypes";
 import { LoginState } from "./interfaces/AccountInterfaces";
+import { router } from "./main";
 
 
     export default defineComponent({
@@ -393,10 +394,10 @@ import { LoginState } from "./interfaces/AccountInterfaces";
                             for (let i = 0; i < loadedFeeds.length; i++) {
                                 await AddSavedFeed(loadedFeeds[i]);
                             }
-                            for (let i = 0; i < FeedState.FeedList.length; i++) {
-                                await LoadFeedPostsAsync(FeedState.FeedList[i].description); //add await if you want these done sequentially
-                                // await new Promise((resolve) => setTimeout(resolve,200)) //use if you want to add a small delay between each API call
+                            if(router.currentRoute.value.path == '/'){
+                                LoadAllFeedPostsAsync();
                             }
+                            else console.log('blocking loading of feeds in FeedColumn')
                             //Set AppState "loading feeds" to false
                             //Update FeedDescription.latestPostDate value after Posts have been loaded
                             SaveFeedChanges(true).catch(err => {
@@ -429,6 +430,7 @@ import { LoginState } from "./interfaces/AccountInterfaces";
                                 //Update FeedList in other tabs/windows, but DO NOT save change to disk
                                 console.log('This message is for updating the FeedColumn state.');
                                 FeedState.FeedList = event.data.data;
+                                AppState.hasFeedDataBeenLoadedAfterInitiallization = true;
                                 break;
                             case BroadcastChannelTarget.AppSettings:
                                 //Update App Settings in other tabs/windows, but DO NOT save change to disk
@@ -581,6 +583,10 @@ import { LoginState } from "./interfaces/AccountInterfaces";
         mounted(){
             this.getFeedDisplayViewWidth();
             this.placeFeedDisplayCenterLine();
+        },
+        beforeRouteEnter(to, from){
+            if(!AppState.hasFeedDataBeenLoadedAfterInitiallization && from.path != '/' && to.path == '/') {LoadAllFeedPostsAsync(); console.log('reoaded feed list because of travelling to root')}
+
         },
         setup () {
             return {}

--- a/src/state/AppState.vue
+++ b/src/state/AppState.vue
@@ -548,5 +548,11 @@ export const AppState = reactive({
     ShowAboutAppModal(){ this.isAboutAppModalVisible = true;},
     /**NOT USED ANYMORE - ROUTING IS USED TO CONTROL MODALS --- Method that causes the "About App" modal to be hidden. */
     HideAboutAppModal(){ this.isAboutAppModalVisible = false;},
+    /**
+     * Value used to determine if Feed data has been loaded after the application is loaded for the first time.
+     * Intended to be used to know if the Feed data needs to be requested when navigating to the main view (`'/'`),
+     * after loading has been prevented because the app started on a route other than the main view (`'/'`).
+     */
+    hasFeedDataBeenLoadedAfterInitiallization:false,
 })
 </script>

--- a/src/state/FeedList.vue
+++ b/src/state/FeedList.vue
@@ -580,6 +580,18 @@ export async function LoadFeedPostsAsync(feedDesc:IFeedDescription){
 }
 
 /**
+ * Method to be used to load the Feed data for all Feeds held in the
+ * `FeedState.FeedList` collection.
+ */
+export async function LoadAllFeedPostsAsync(){
+    for (let i = 0; i < FeedState.FeedList.length; i++) {
+        await LoadFeedPostsAsync(FeedState.FeedList[i].description); //add await if you want these done sequentially
+        // await new Promise((resolve) => setTimeout(resolve,200)) //use if you want to add a small delay between each API call
+    }
+    AppState.hasFeedDataBeenLoadedAfterInitiallization = true;
+}
+
+/**
  * Method used to get Feed data. It uses the Feed Type to choose the correct process needed
  * to return the correct data.
  * @param feedType The type of Feed this data is for. Of type `FeedEnums.Types`.

--- a/src/state/FeedList.vue
+++ b/src/state/FeedList.vue
@@ -829,6 +829,7 @@ export async function RefreshAllFeeds(postsToGet:number=10){
     FeedState.FeedList.forEach(feed => {
         RefreshFeed(feed.description.feedId,new Date(),postsToGet);
     });
+    AppState.hasFeedDataBeenLoadedAfterInitiallization = true;
 }
 
 /**


### PR DESCRIPTION
Modifies the initialization process of the application so that the Feeds in the `FeedList` collection will not load if the route the app is starting on is not the "Main View" route (`/`). The app will request Feed data once the User navigates back to the "Main View" route.