### PR TITLE
Hotfix #287 - `ImageContainer` file extension fix

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -22,6 +22,7 @@ declare module 'vue' {
     CustomFeedButtonPlaceholder: typeof import('./src/components/Placeholder/CustomFeedButtonPlaceholder.vue')['default']
     DbDebugModal: typeof import('./src/components/Debug/DbDebugModal.vue')['default']
     EmbedExternal: typeof import('./src/components/Utilities/EmbedExternal.vue')['default']
+    ExternalLink: typeof import('./src/components/Utilities/ExternalLink.vue')['default']
     FeedButton: typeof import('./src/components/Navbar/FeedButton.vue')['default']
     FeedColumn: typeof import('./src/components/Feed/FeedColumn.vue')['default']
     FeedEditModal: typeof import('./src/components/Feed/FeedEditModal.vue')['default']

--- a/src/components/Login/LoginModal.vue
+++ b/src/components/Login/LoginModal.vue
@@ -138,7 +138,7 @@
                         <div class="text-sm text-red-500 whitespace-pre-line">{{ validationErrorMessage }}</div>
                         <div class="flex text-sm text-primary">
                             <div>Dont have an account? Create one using the</div>
-                            <a href="https://bsky.app/" target="_blank" class="ml-1 text-blueskyBlue hover:underline">official client</a>
+                            <ExternalLink link-url="http://bsky.app/" class="ml-1 text-blueskyBlue hover:text-blueskyBlue hover:underline">official client</ExternalLink>
                             <div>.</div>
                         </div>
                     </div>
@@ -173,6 +173,7 @@ import RadioBarButton from '../Utilities/RadioBarButton.vue';
 import { GenerateUniqueID } from '../../helpers/generators';
 import ConfirmModal from '../Utilities/ConfirmModal.vue';
 import { BroadcastChannelTarget, BroadcastObject, toRawDeep } from '../../types/BroadcastChannelTypes';
+import ExternalLink from '../Utilities/ExternalLink.vue';
 
 /**
  * Asks the User if they're sure they would like to delete the selected
@@ -189,6 +190,7 @@ export default defineComponent({
         SquareButton,
         RadioBarButton,
         ConfirmModal,
+        ExternalLink,
     },
     data(){
         return{

--- a/src/components/Settings/AboutAppModal.vue
+++ b/src/components/Settings/AboutAppModal.vue
@@ -38,6 +38,13 @@
             <div class="flex flex-col overflow-y-auto pt-2">
                 <div class="px-4 text-xl font-semibold">Changelog:</div>
                 <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
+                    <div class="font-semibold">March 13th 2026</div>
+                    <ul class="list-disc list-inside h-full py-1 text-sm">
+                        <li>Updated app so that the scroll position is saved and restored when navigating a Post Thread with the "Post Focus Modal" (<ExternalLink link-url="https://github.com/sondaismith/moongate/pull/286" link-text="#286"/>).
+                        </li>
+                    </ul>
+                </div>
+                <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
                     <div class="font-semibold">February 10th 2026</div>
                     <ul class="list-disc list-inside h-full py-1 text-sm">
                         <li>Updated app so that application state is synced between all open web-based application instances.
@@ -155,13 +162,7 @@
                 </div>
             </div>
             <div class="flex gap-1 px-4 py-2 text-xs">
-                <div>Any issues? Report</div>
-                <a v-if="!isTauri()" target="_blank"
-                :href="issuesURL"
-                class="text-blue-500 hover:text-blue-300 cursor-pointer">here!</a>
-                <a v-else
-                @click="(e) => showOptionsMenu(e,issuesURL)"
-                class="text-blue-500 hover:text-blue-300 cursor-pointer">here!</a>
+                <div>Any issues? Report <ExternalLink :link-url="issuesURL" link-text="here!"/></div>
             </div>
         </div>
     </div>
@@ -179,14 +180,7 @@ import { IOptionMenuItem, ItemType } from '../Utilities/OptionsMenu.vue';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import AppLogo from '../SVG/AppLogo.vue';
 import { GetVersion, IVersionDetails } from '../../lib/api/VersionService';
-
-/**
- * Method used to open link in the system's default browser.
- * @param url The URL to open in the default browser.
- */
-async function OpenLink(url:string){
-    await openUrl(url);
-}
+import ExternalLink from '../Utilities/ExternalLink.vue';
 
 export default defineComponent({
     props:{
@@ -196,7 +190,8 @@ export default defineComponent({
         }
     },
     components:{
-        AppLogo
+        AppLogo,
+        ExternalLink,
     },
     data(){
         return{
@@ -220,18 +215,6 @@ export default defineComponent({
         },
         closeModal(){
             this.$router.push('/');
-        },
-        /**
-         * Shows Options Menu allowing user to perform different actions
-         * relating to the selected link.
-         */
-        showOptionsMenu(e:MouseEvent, linkURL:string){
-            e.preventDefault();
-            OptionsMenuState.currentMenuItems = [
-                {Icon:MingcuteWorld2Line,Label:'Open in Default Browser',Action:function(){OpenLink(linkURL)},Type:ItemType.Option},
-                {Icon:MingcuteCopyLine,Label:'Copy link to clipboard',Action:function(){CopyTextToClipboard(linkURL,'link')},Type:ItemType.Option},
-            ] as IOptionMenuItem[]
-            OptionsMenuState.showOptionMenu(e);
         },
     },
     created() {

--- a/src/components/Settings/AboutAppModal.vue
+++ b/src/components/Settings/AboutAppModal.vue
@@ -12,10 +12,11 @@
                         <div class="text-sm sm:text-base font-light">Version: {{ versionDetails.version }}-{{ versionDetails.commitHash }}<span class="align-super text-xs">{{isTauri() ? 'Tauri' : 'Web'}}</span></div>
                         <div class="italic text-[10px] leading-[10px]">{{ versionDetails.buildDate }}</div>
                     </div>
-                    <a :href="repoURL" target="_blank" title="View GitHub Repo" class="ml-auto mr-4 p-2 shadow-none text-xl
-                    transition-colors border-none rounded hover:bg-aboutPageBannerBtnHover focus-visible:bg-aboutPageBannerBtnHover">
+                    <ExternalLink :link-url="repoURL" title="View GitHub Repo" class="text-primary hover:text-primary ml-auto mr-4 p-2
+                    shadow-none text-xl transition-colors border-none rounded hover:bg-aboutPageBannerBtnHover
+                    focus-visible:bg-aboutPageBannerBtnHover">
                         <i-simple-icons:github/>
-                    </a>
+                    </ExternalLink>
                 </div>
             </div>
             <div class="flex flex-col h-full px-4 *:py-1  divide-outline divide-y">
@@ -25,14 +26,14 @@
             </div>
             <div class="flex flex-col md:flex-row md:items-center gap-1 px-4 pb-2 text-sm select-none">
                 <div class="font-bold">Like the app? Support development by buying me a coffee:</div>
-                <a :href="donateURL" target="_blank" class="group flex self-start rounded p-1
+                <ExternalLink :link-url="donateURL" class="group flex self-start rounded p-1 text-primary
                 transition-colors bg-donationButtonBG cursor-pointer outline-none focus-visible:outline-feedtypeBtnFocusHighlight">
                     <div class="flex gap-1 items-center">
                         <i-simple-icons:kofi class="transition-colors group-hover:text-donationButtonIconHover
                         group-focus-visible:text-donationButtonIconHover"/>
                         <div class="text-primary">Support</div>
                     </div>
-                </a>
+                </ExternalLink>
             </div>
             <div class="h-0.5 bg-outline"></div>
             <div class="flex flex-col overflow-y-auto pt-2">
@@ -40,7 +41,7 @@
                 <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
                     <div class="font-semibold">March 13th 2026</div>
                     <ul class="list-disc list-inside h-full py-1 text-sm">
-                        <li>Updated app so that the scroll position is saved and restored when navigating a Post Thread with the "Post Focus Modal" (<ExternalLink link-url="https://github.com/sondaismith/moongate/pull/286" link-text="#286"/>).
+                        <li>Updated app so that the scroll position is saved and restored when navigating a Post Thread with the "Post Focus Modal" (<ExternalLink link-url="https://github.com/sondaismith/moongate/pull/286">#286</ExternalLink>).
                         </li>
                     </ul>
                 </div>
@@ -162,7 +163,7 @@
                 </div>
             </div>
             <div class="flex gap-1 px-4 py-2 text-xs">
-                <div>Any issues? Report <ExternalLink :link-url="issuesURL" link-text="here!"/></div>
+                <div>Any issues? Report <ExternalLink :link-url="issuesURL">here!</ExternalLink></div>
             </div>
         </div>
     </div>

--- a/src/components/Settings/AboutAppModal.vue
+++ b/src/components/Settings/AboutAppModal.vue
@@ -39,6 +39,14 @@
             <div class="flex flex-col overflow-y-auto pt-2">
                 <div class="px-4 text-xl font-semibold">Changelog:</div>
                 <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
+                    <div class="font-semibold">March 17th 2026</div>
+                    <ul class="list-disc list-inside h-full py-1 text-sm">
+                        <li>Fixed issue where image containers could not correctly idenntify the file extension of the new WEBP images the Bluesky CDN delivers by default.</li>
+                        <li>Added ability to choose whether to save images as a WEBP or JPEG.</li>
+                        <li>See details here: (<ExternalLink link-url="https://github.com/sondaismith/moongate/pull/288">#288</ExternalLink>)</li>
+                    </ul>
+                </div>
+                <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
                     <div class="font-semibold">March 13th 2026</div>
                     <ul class="list-disc list-inside h-full py-1 text-sm">
                         <li>Updated app so that the scroll position is saved and restored when navigating a Post Thread with the "Post Focus Modal" (<ExternalLink link-url="https://github.com/sondaismith/moongate/pull/286">#286</ExternalLink>).

--- a/src/components/Utilities/ExternalLink.vue
+++ b/src/components/Utilities/ExternalLink.vue
@@ -1,10 +1,10 @@
 <template>
     <a v-if="!isTauri()" target="_blank"
     :href="linkUrl"
-    class="text-blue-500 hover:text-blue-300 cursor-pointer">{{ linkText }}</a>
+    class="text-blue-500 hover:text-blue-300 cursor-pointer"><slot>{{ defaultText }}</slot></a>
     <a v-else
-    @click="(e) => showOptionsMenu(e,linkUrl)"
-    class="text-blue-500 hover:text-blue-300 cursor-pointer">{{ linkText }}</a>
+    @click="(e) => showOptionsMenu(e,linkUrl)" @keydown.enter="(e) => showOptionsMenu(e,linkUrl)" tabindex="0"
+    class="text-blue-500 hover:text-blue-300 cursor-pointer"><slot>{{ defaultText }}</slot></a>
 </template>
 
 <script lang="ts">
@@ -26,13 +26,17 @@ async function OpenLink(url:string){
     await openUrl(url);
 }
 
+/**Default text label that will be used if content is not provided. */
+let defaultText = '[Please Set Link Text]';
+
+/**
+ * Component that allows for interacting with external links. Clicking a created link
+ * will open in a new tab when on the web, while on Desktop the User can choose to open
+ * the link in their default browser or copy the link.
+ */
 export default defineComponent({
+    name:'ExternalLink',
     props:{
-        /**The text label to use for the external link. */
-        linkText:{
-            type:String,
-            default:'Please Set Link Text'
-        },
         /**The URL link to open when the control is clicked. */
         linkUrl:{
             type:String,
@@ -42,6 +46,8 @@ export default defineComponent({
     data(){
         return{
             isTauri,
+            /**Default text label that will be used if content is not provided. */
+            defaultText,
         }
     },
     methods:{
@@ -49,7 +55,7 @@ export default defineComponent({
          * Shows Options Menu allowing user to perform different actions
          * relating to the selected link.
          */
-        showOptionsMenu(e:MouseEvent, linkURL:string){
+        showOptionsMenu(e:MouseEvent|KeyboardEvent, linkURL:string){
             e.preventDefault();
             OptionsMenuState.currentMenuItems = [
                 {Icon:MingcuteWorld2Line,Label:'Open in Default Browser',Action:function(){OpenLink(linkURL)},Type:ItemType.Option},

--- a/src/components/Utilities/ExternalLink.vue
+++ b/src/components/Utilities/ExternalLink.vue
@@ -1,0 +1,65 @@
+<template>
+    <a v-if="!isTauri()" target="_blank"
+    :href="linkUrl"
+    class="text-blue-500 hover:text-blue-300 cursor-pointer">{{ linkText }}</a>
+    <a v-else
+    @click="(e) => showOptionsMenu(e,linkUrl)"
+    class="text-blue-500 hover:text-blue-300 cursor-pointer">{{ linkText }}</a>
+</template>
+
+<script lang="ts">
+import MingcuteCopyLine from '~icons/mingcute/copy-line';
+import MingcuteWorld2Line from '~icons/mingcute/world-2-line';
+
+import { defineComponent } from 'vue';
+import { isTauri } from '@tauri-apps/api/core';
+import { OptionsMenuState } from '../../state/OptionsMenuState.vue';
+import { CopyTextToClipboard } from '../../state/AppState.vue';
+import { IOptionMenuItem, ItemType } from './OptionsMenu.vue';
+import { openUrl } from '@tauri-apps/plugin-opener';
+
+/**
+ * Method used to open link in the system's default browser.
+ * @param url The URL to open in the default browser.
+ */
+async function OpenLink(url:string){
+    await openUrl(url);
+}
+
+export default defineComponent({
+    props:{
+        /**The text label to use for the external link. */
+        linkText:{
+            type:String,
+            default:'Please Set Link Text'
+        },
+        /**The URL link to open when the control is clicked. */
+        linkUrl:{
+            type:String,
+            required:true
+        },
+    },
+    data(){
+        return{
+            isTauri,
+        }
+    },
+    methods:{
+        /**
+         * Shows Options Menu allowing user to perform different actions
+         * relating to the selected link.
+         */
+        showOptionsMenu(e:MouseEvent, linkURL:string){
+            e.preventDefault();
+            OptionsMenuState.currentMenuItems = [
+                {Icon:MingcuteWorld2Line,Label:'Open in Default Browser',Action:function(){OpenLink(linkURL)},Type:ItemType.Option},
+                {Icon:MingcuteCopyLine,Label:'Copy link to clipboard',Action:function(){CopyTextToClipboard(linkURL,'link')},Type:ItemType.Option},
+            ] as IOptionMenuItem[]
+            OptionsMenuState.showOptionMenu(e);
+        },
+    }
+})
+</script>
+
+<style scoped>
+</style>

--- a/src/components/Utilities/ImageContainer.vue
+++ b/src/components/Utilities/ImageContainer.vue
@@ -130,7 +130,7 @@ async function saveImageWithAuthor(image:ViewImage|View, index:number, author:st
         if(author) safeHandle =  author.replace (/\./g,'_');
         AppState.fileSaveDetails.full = `${fileName} by ${safeHandle}`;
         AppState.fileSaveDetails.originalFilename = fileName ? fileName : '';
-        AppState.fileSaveDetails.extension = '.jpg'; //Need to create method that parses image URL to determine extension (the @jpeg part)
+        AppState.fileSaveDetails.extension = '.webp'; //Need to create method that parses image URL to determine extension (the @jpeg part)
         AppState.fileSaveDetails.handle = author ? author : '';
         AppState.fileSaveDetails.postText = postText ? postText : '';
 
@@ -231,7 +231,8 @@ export default defineComponent({
         getImageExtension(url:string):string{
             if(url.endsWith('jpeg')) return 'jpg'
             else if(url.endsWith('png')) return 'png'
-            return 'N/A';
+            // return 'N/A';
+            return 'webp';
         },
         /**
          * Shows Options Menu allowing user to perform different actions

--- a/src/components/Utilities/SaveMediaModal.vue
+++ b/src/components/Utilities/SaveMediaModal.vue
@@ -2,7 +2,7 @@
     <div class="absolute flex z-50 w-full h-full">
         <div data-testid="saveMediaModal-close" @click="closeModal" class="absolute w-full h-full bg-slate-800/60 backdrop-blur-sm"></div>
         <div data-testid="saveMediaModal" class="relative flex flex-col max-w-[48rem] w-4/5 m-auto z-50
-        rounded bg-savemodalBG border border-slate-800 overflow-hidden">
+        rounded bg-savemodalBG border border-slate-800 overflow-hidden drop-shadow-lg">
             <div class="px-2 py-1 bg-banner border-b border-slate-500">Save as</div>
             <div v-if="!isAwaitingPostData" class="flex flex-col gap-2 p-3 overflow-hidden">
                 <img v-if="!AppState.saveMedia.uri" @contextmenu.prevent :src="AppState.saveMedia.thumb" class="self-start rounded max-h-32 max-w-full bg-slate-500 overflow-hidden"
@@ -37,24 +37,26 @@
                     :style="{'width' : downloadProgress+'%', 'transition':'width 0.4s ease'}"></div>
                 </div>
                 <SquareButton v-if="isTauri()" @click="saveImage()" title="Save Image [.webp]"
-                :is-disabled="!isFileNameValid || !isFolderSyntaxValid || isDownloading">
+                :is-disabled="!isFileNameValid || !isFolderSyntaxValid || isDownloading"
+                class="bg-savemodalBtn hover:bg-savemodalBtnHover">
                     Save Image
                 </SquareButton>
                 <!-- <SquareButton v-else :is-disabled="isDownloading" @click="saveImageWebCORSSafe" title="Opens in new tab">Save Image</SquareButton> -->
                 <SquareButton v-else :is-disabled="isDownloading"
                 @click="downloadFileFromBskyCDN((AppState.saveMedia as ViewImage).fullsize ? (AppState.saveMedia as ViewImage).fullsize : (AppState.saveMedia.uri as string), AppState.fileSaveDetails.full)"
-                title="Save Image [.webp]">
+                title="Save Image [.webp]" class="bg-savemodalBtn hover:bg-savemodalBtnHover">
                     <div>Save Image</div>
                     <!-- <i-mingcute:loading-fill v-if="isDownloading" class="spinner"/> -->
                 </SquareButton>
                 <SquareButton v-if="isTauri()" @click="saveImage(true)" title="Save Image [.jpg]"
-                :is-disabled="!isFileNameValid || !isFolderSyntaxValid || isDownloading">
+                :is-disabled="!isFileNameValid || !isFolderSyntaxValid || isDownloading"
+                class="bg-savemodalBtn hover:bg-savemodalBtnHover">
                     Save Image as JPG w/ Metadata
                 </SquareButton>
                 <!-- <SquareButton v-else :is-disabled="isDownloading" @click="saveImageWebCORSSafe" title="Opens in new tab">Save Image</SquareButton> -->
                 <SquareButton v-else :is-disabled="isDownloading"
                 @click="downloadFileFromBskyCDN((AppState.saveMedia as ViewImage).fullsize ? (AppState.saveMedia as ViewImage).fullsize : (AppState.saveMedia.uri as string), AppState.fileSaveDetails.full, true)"
-                title="Save Image [.jpg]">
+                title="Save Image [.jpg]" class="bg-savemodalBtn hover:bg-savemodalBtnHover">
                     <div>Save Image as JPG w/ Metadata</div>
                     <!-- <i-mingcute:loading-fill v-if="isDownloading" class="spinner"/> -->
                 </SquareButton>

--- a/src/components/Utilities/SaveMediaModal.vue
+++ b/src/components/Utilities/SaveMediaModal.vue
@@ -30,20 +30,32 @@
                     <InLaInput :is-disabled="true" text-label="Save Folder" :model-value="AppState.lastMediaSaveDirectory.trim() != '' ? AppState.lastMediaSaveDirectory : 'Please select save folder'"/>
                 </div>
                 <div v-show="!isFileNameValid" class="text-xs text-red-500">Invalid file name</div>
-                <div v-show="isFileNameTaken" class="text-xs text-orange-300">File already exists, will be overwritten</div>
+                <div v-show="isFileNameTaken" class="text-xs text-orange-300">WEBP File already exists, will be overwritten</div>
+                <div v-show="isFileNameTakenJpg" class="text-xs text-orange-300">JPG File already exists, will be overwritten</div>
                 <div v-if="isTauri()" class="rounded h-3 overflow-hidden bg-slate-400 border border-slate-800">
                     <div class="rounded bg-blue-500 h-full w-0"
                     :style="{'width' : downloadProgress+'%', 'transition':'width 0.4s ease'}"></div>
                 </div>
-                <SquareButton v-if="isTauri()" @click="saveImage" title="Save Image"
+                <SquareButton v-if="isTauri()" @click="saveImage()" title="Save Image [.webp]"
                 :is-disabled="!isFileNameValid || !isFolderSyntaxValid || isDownloading">
                     Save Image
                 </SquareButton>
                 <!-- <SquareButton v-else :is-disabled="isDownloading" @click="saveImageWebCORSSafe" title="Opens in new tab">Save Image</SquareButton> -->
                 <SquareButton v-else :is-disabled="isDownloading"
                 @click="downloadFileFromBskyCDN((AppState.saveMedia as ViewImage).fullsize ? (AppState.saveMedia as ViewImage).fullsize : (AppState.saveMedia.uri as string), AppState.fileSaveDetails.full)"
-                title="Download Image">
+                title="Save Image [.webp]">
                     <div>Save Image</div>
+                    <!-- <i-mingcute:loading-fill v-if="isDownloading" class="spinner"/> -->
+                </SquareButton>
+                <SquareButton v-if="isTauri()" @click="saveImage(true)" title="Save Image [.jpg]"
+                :is-disabled="!isFileNameValid || !isFolderSyntaxValid || isDownloading">
+                    Save Image as JPG w/ Metadata
+                </SquareButton>
+                <!-- <SquareButton v-else :is-disabled="isDownloading" @click="saveImageWebCORSSafe" title="Opens in new tab">Save Image</SquareButton> -->
+                <SquareButton v-else :is-disabled="isDownloading"
+                @click="downloadFileFromBskyCDN((AppState.saveMedia as ViewImage).fullsize ? (AppState.saveMedia as ViewImage).fullsize : (AppState.saveMedia.uri as string), AppState.fileSaveDetails.full, true)"
+                title="Save Image [.jpg]">
+                    <div>Save Image as JPG w/ Metadata</div>
                     <!-- <i-mingcute:loading-fill v-if="isDownloading" class="spinner"/> -->
                 </SquareButton>
             </div>
@@ -116,8 +128,10 @@ export default defineComponent({
             progressSum:0,
             /**Indicates value `progressSum` needs to reach for download to be completed. */
             progressGoal:0,
-            /**State value indicating if a file with the same name already exists in current directory. */
+            /**State value indicating if a WEBP file with the same name already exists in current directory. */
             isFileNameTaken:false,
+            /**State value indicating if a JPG file with the same name already exists in current directory. */
+            isFileNameTakenJpg:false,
             /**Are we waiting for the related Post's data to be returned. */
             isAwaitingPostData:false,
             /**Post data used to download related image. */
@@ -135,21 +149,27 @@ export default defineComponent({
             });
             if(path) AppState.lastMediaSaveDirectory = path;
             this.checkIfFileNameAlreadyExists();
+            this.checkIfFileNameAlreadyExistsJpg();
         },
         /**
          * Method used to download images with metadata when using the application via
          * desktop app (Tauri web-view).
+         * @param fetchAsJpeg Value indicating if we should request the Bluesky CDN to return the image as a JPEG.
          */
-        async saveImage(){
+        async saveImage(fetchAsJpeg:boolean=false){
             this.progressSum = 0;
             this.progressGoal = 0;
             this.isDownloading = true;
             let downloadURL = '';
             if(!AppState.saveMedia.uri) downloadURL = (AppState.saveMedia as ViewImage).fullsize
             else downloadURL = (AppState.saveMedia as ViewExternal).uri
+            if(fetchAsJpeg){
+                AppState.fileSaveDetails.extension = '.jpg';
+                downloadURL+='@jpeg';
+            }
             await download(
                 downloadURL,
-                `${AppState.lastMediaSaveDirectory}\\${AppState.fileSaveDetails.full}.${AppState.fileSaveDetails.extension}`,
+                `${AppState.lastMediaSaveDirectory}\\${AppState.fileSaveDetails.full}${AppState.fileSaveDetails.extension}`,
                 ({ progress, total }) => {
                     this.progressSum += progress;
                     this.progressGoal = total;
@@ -157,10 +177,10 @@ export default defineComponent({
                 }
             )
             .then(_ => {
-                if(isTauri() && AppState.fileSaveDetails.extension != '.gif'){
+                if(isTauri() && AppState.fileSaveDetails.extension == '.jpg'){
                     //in Tauri webview, not browser
                     invoke('write_metadata_to_file', ({
-                        imageFile:`${AppState.lastMediaSaveDirectory}\\${AppState.fileSaveDetails.full}.${AppState.fileSaveDetails.extension}`,
+                        imageFile:`${AppState.lastMediaSaveDirectory}\\${AppState.fileSaveDetails.full}${AppState.fileSaveDetails.extension}`,
                         userHandle:`@${AppState.fileSaveDetails.handle}`,//AppState.fileSaveDefaultFilename.split(' ').pop()?.split('.')[0],
                         description:AppState.fileSaveDetails.postText
                     }));
@@ -209,10 +229,11 @@ export default defineComponent({
             }
             else{ AppState.fileSaveDetails.full = '' }
             this.checkIfFileNameAlreadyExists();
+            this.checkIfFileNameAlreadyExistsJpg();
         },
         async checkIfFileNameAlreadyExists(){
             if(this.isFileNameValid && this.isFolderSyntaxValid){
-                await exists(`${AppState.lastMediaSaveDirectory}/${AppState.fileSaveDetails.full}.${AppState.fileSaveDetails.extension}`)
+                await exists(`${AppState.lastMediaSaveDirectory}/${AppState.fileSaveDetails.full}.webp`)
                 .then(res => {
                     this.isFileNameTaken = res;
                 })
@@ -220,6 +241,18 @@ export default defineComponent({
             }
             else{
                 this.isFileNameTaken = false;
+            }
+        },
+        async checkIfFileNameAlreadyExistsJpg(){
+            if(this.isFileNameValid && this.isFolderSyntaxValid){
+                await exists(`${AppState.lastMediaSaveDirectory}/${AppState.fileSaveDetails.full}.jpg`)
+                .then(res => {
+                    this.isFileNameTakenJpg = res;
+                })
+                .catch(err => console.log(err));
+            }
+            else{
+                this.isFileNameTakenJpg = false;
             }
         },
         /**
@@ -250,8 +283,10 @@ export default defineComponent({
          * Code is modified from https://muhimasri.com/blogs/how-to-save-files-in-javascript/#download-and-save-a-file-using-the-fetch-api
          * @param url The URL of the file to download. Should begin with 'https://cdn.bsky.app'.
          * @param filename The string to use as the default/starting file name.
+         * @param fetchAsJpeg Value indicating if we are requesting the Bluesky CDN to return the image as a JPEG.
+         *
          */
-        async downloadFileFromBskyCDN(url:string, filename:string) {
+        async downloadFileFromBskyCDN(url:string, filename:string, fetchAsJpeg:boolean=false) {
             const target = `${import.meta.env.VITE_BSKY_MEDIA_DOWNLOAD_PROXY_TARGET}`;
             if(!url.includes(target)){
                 toast.add({summary:'Error', detail:`URL provided to download must be link to Bluesky CDN`, severity:'error', group:'tr', life:3000});
@@ -259,7 +294,7 @@ export default defineComponent({
             }
             else{
                 this.isDownloading = true;
-                await fetch(CreateBskyMediaDownloadURL(url),{
+                await fetch(CreateBskyMediaDownloadURL(url,fetchAsJpeg),{
                     headers:{
                         Accept:
                         "image/png, image/jpeg, image/*",
@@ -370,7 +405,7 @@ export default defineComponent({
                 if(typeof this.handle != 'undefined') safeHandle =  this.handle.replace (/\./g,'_');
                 AppState.fileSaveDetails.full = `${fileName} by ${safeHandle}`;
                 AppState.fileSaveDetails.originalFilename = fileName ? fileName : '';
-                AppState.fileSaveDetails.extension = '.jpg'; //Need to create method that parses image URL to determine extension (the @jpeg part)
+                AppState.fileSaveDetails.extension = '.webp'; //Need to create method that parses image URL to determine extension (the @jpeg part)
                 AppState.fileSaveDetails.handle = typeof this.handle != 'undefined' ? this.handle : '';
                 // AppState.fileSaveDetails.postText = postText ? postText : '';
 
@@ -388,6 +423,7 @@ export default defineComponent({
     },
     mounted(){
         this.checkIfFileNameAlreadyExists();
+        this.checkIfFileNameAlreadyExistsJpg();
     },
     beforeUnmount(){
         AppState.saveMedia = {alt:'unset',description:'unset',fullsize:'',title:'unset',uri:'unset',thumb:'unset'};//"clear" saveMedia variable

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -157,10 +157,11 @@ export function CreateBskyWeblink(postUri:string, handle:string=""):string|undef
  * See {@link '../../vite.config.ts'} and {@link '../../.env'} for variables
  * that make the whole thing work..
  * @param mediaURL The URL to convert.
+ * @param fetchAsJpeg Value indicating we are requesting the Bluesky CDN to return the image as a JPEG.
  * @returns The URL to use to download media from Bluesky's servers via
  * the application's proxy.
  */
-export function CreateBskyMediaDownloadURL(mediaURL:string){
+export function CreateBskyMediaDownloadURL(mediaURL:string, fetchAsJpeg:boolean=false){
     //If URL is empty string
     if(mediaURL.trim() == '') throw new Error('Provided URL is empty.');
     //Get environment variables
@@ -171,5 +172,5 @@ export function CreateBskyMediaDownloadURL(mediaURL:string){
     if(!routeRegex.test(mediaURL)) throw new Error('Invalid URL');
     //discard "target" part of URL
     var proxyMediaURL = mediaURL.split(target)[1];
-    return `${proxyMediaURL}`;
+    return `${proxyMediaURL}${fetchAsJpeg?'@jpeg':''}`;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -27,7 +27,7 @@
         --color-post-focus-bg: oklch(12.9% 0.042 264.695);
         --color-border: oklch(37.2% 0.044 257.287);
         --color-border-lighter: oklch(44.6% 0.043 257.281);
-        --color-banner: oklch(20.8% 0.042 265.755);
+        --color-banner: theme(colors.slate.900);
         --color-user-focus-bg: oklch(27.9% 0.041 260.031);
         --color-disabled: oklch(55.1% 0.027 264.364);
         --color-disabled-bg: oklch(37.2% 0.044 257.287);
@@ -51,8 +51,10 @@
         --color-login-btn: oklch(48.8% 0.243 264.376);
         --color-login-btn-hover: oklch(62.3% 0.214 259.815);
         --color-login-host-hover:theme(colors.slate.950);
-        --color-savemodal-bg: oklch(37.2% 0.044 257.287);
+        --color-savemodal-bg: theme(colors.slate.800);
         --color-savemodal-ext-bg: oklch(27.9% 0.041 260.031);
+        --color-savemodal-btn: #3b6797;
+        --color-savemodal-btn-hover: #6d8fb5;
         --color-embed-hover-bg:oklch(27.9% 0.041 260.031);
         --color-embed-hover-border:oklch(55.4% 0.046 257.417);
         --color-scrollbar-track:theme(colors.slate.700);
@@ -122,7 +124,7 @@
     --color-post-focus-bg: oklch(100% 0 0);
     --color-border: oklch(37.2% 0.044 257.287);
     --color-border-lighter: oklch(55.4% 0.046 257.417);
-    --color-banner: oklch(70.4% 0.04 256.788);
+    --color-banner: theme(colors.slate.400);
     --color-user-focus-bg: oklch(100% 0 0);
     --color-disabled: oklch(70.7% 0.022 261.325);
     --color-disabled-bg: oklch(87.2% 0.01 258.338);
@@ -146,8 +148,10 @@
     --color-login-btn: oklch(62.3% 0.214 259.815);
     --color-login-btn-hover: oklch(70.7% 0.165 254.624);
     --color-login-host-hover:theme(colors.blue.100);
-    --color-savemodal-bg: oklch(86.9% 0.022 252.894);
+    --color-savemodal-bg: theme(colors.slate.200);
     --color-savemodal-ext-bg: oklch(70.4% 0.04 256.788);
+    --color-savemodal-btn: #74a5db;
+    --color-savemodal-btn-hover: #9bbfe8;
     --color-embed-hover-bg:oklch(92.9% 0.013 255.508);
     --color-embed-hover-border:oklch(70.7% 0.165 254.624);
     --color-scrollbar-track:theme(colors.slate.300);

--- a/src/state/AppState.vue
+++ b/src/state/AppState.vue
@@ -491,7 +491,7 @@ export const AppState = reactive({
         /**The original filename the image had on the server. */
         originalFilename:'',
         /**The file extension of the file to be downloaded. */
-        extension:'.jpg',
+        extension:'.webp',
         /**The handle of the account that posted/shared the image. */
         handle:'',
         /**The text (if any) that was posted along with the image. */

--- a/src/state/OptionsMenuState.vue
+++ b/src/state/OptionsMenuState.vue
@@ -12,7 +12,7 @@ export const OptionsMenuState = reactive({
     /**Defines the list of menu options that will be displayed. */
     currentMenuItems: [] as IOptionMenuItem[],
     /**Shows the Options Menu. */
-    showOptionMenu(event:MouseEvent){
+    showOptionMenu(event:MouseEvent|KeyboardEvent){
         this.isOptionsMenuVisible = true;
         var menu = document.getElementById('options-btn-menu');//important
         //delay to allow menu dimensions to update after being filled with items
@@ -47,17 +47,17 @@ export const OptionsMenuState = reactive({
         var menuSafePos = {x:0,y:0};
         menuSafePos = {x:event.clientX, y:event.clientY};
         let clickTargetRect = (event.target as Element).getBoundingClientRect();
-        if(event.pointerType == '') menuSafePos = {x:clickTargetRect.x,y:clickTargetRect.y};
+        if(typeof event.pointerType == 'undefined') menuSafePos = {x:clickTargetRect.x,y:clickTargetRect.y};
         var xTarget = menuSafePos.x;
         var yTarget = menuSafePos.y;
         var menuYClearence = viewportHeight - (menuHeight+yTarget);
         var menuXClearence = viewportWidth - (menuWidth+xTarget);
 
         if(menuYClearence < 0){
-            yTarget = event.clientY-menuHeight;
+            yTarget = yTarget-menuHeight;
         }
         if(menuXClearence < 0){
-            xTarget = event.clientX-menuWidth;
+            xTarget = xTarget-menuWidth;
         }
         menuSafePos = {x:xTarget, y:yTarget};
         return menuSafePos;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,6 +53,8 @@ export default {
         feedtypeBtnFocusHighlight: "oklch(from var(--color-feedtype-btn-focus-highlight) l c h / <alpha-value>)",
         savemodalBG: "oklch(from var(--color-savemodal-bg) l c h / <alpha-value>)",
         savemodalFileExtBG: "oklch(from var(--color-savemodal-ext-bg) l c h / <alpha-value>)",
+        savemodalBtn: "oklch(from var(--color-savemodal-btn) l c h / <alpha-value>)",
+        savemodalBtnHover: "oklch(from var(--color-savemodal-btn-hover) l c h / <alpha-value>)",
         embedHoverBG: "oklch(from var(--color-embed-hover-bg) l c h / <alpha-value>)",
         embedHoverBorder: "oklch(from var(--color-embed-hover-border) l c h / <alpha-value>)",
         scrollbarTrack: "oklch(from var(--color-scrollbar-track) l c h / <alpha-value>)",


### PR DESCRIPTION
- Made changes to `ImageContainer` so the change to Bluesky's CDN to serve `WEBP` images is handled correctly on the "file extension" label.
- Updated `SaveMediaModal` to allow Users to save images as `.jpg` files in addition to the `WEBP` default. Works on the Web and Tauri/Desktop versions of the application.
- Created new `ExternalLink` component that is to be used wherever a link to an external web page is needed. The new component works differently depending on if the Web or Desktop version of the application is being used.
- Fixed issue where `OptionMenuState` could incorrectly calculate a "safe" area to place the "Options Menu".