### PR TITLE
Hotfix #289 - Fix issue with Reply scroll position not being saved/restored when using "mobile" view

### DIFF
--- a/src/Sidebar.vue
+++ b/src/Sidebar.vue
@@ -583,6 +583,14 @@ import { router } from "./main";
         mounted(){
             this.getFeedDisplayViewWidth();
             this.placeFeedDisplayCenterLine();
+            // AppState.setupWindowResizeListener();
+            //Calculate if app is being displayed with "mobile layout"
+            AppState.windowWidth = window.innerWidth;
+            if(AppState.windowWidth<AppState.mobileLayoutWidth) AppState.usingMobileLayout = true;
+            window.addEventListener('resize', AppState.updateWindowResizedWithTimeout);
+        },
+        beforeUnmount(){
+            AppState.removeWindowResizeListener();
         },
         beforeRouteEnter(to, from){
             if(!AppState.hasFeedDataBeenLoadedAfterInitiallization && from.path != '/' && to.path == '/') {LoadAllFeedPostsAsync(); console.log('reoaded feed list because of travelling to root')}

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -19,7 +19,7 @@
                 :style="[isScrollToTopVisible ? {'opacity':'100%'} : {'opacity':'0%'}]"><i-mdi:format-vertical-align-top/></div>
                 <div v-if="hasImageMedia" @click="showImageFullscreen(getEmbededImageViewImageObjects[currentMediaIndex])"
                 class="flex rounded-lg cursor-pointer bg-btn items-center px-3 text-primary text-sm sm:hidden">View Image</div>
-                <div @click="hideModal" class="flex rounded-lg cursor-pointer bg-btn px-3 items-center text-primary sm:hidden"><i-mingcute:close-fill/></div>
+                <div data-testid="postFocusModal-close-button-mobile" @click="hideModal" class="flex rounded-lg cursor-pointer bg-btn px-3 items-center text-primary sm:hidden"><i-mingcute:close-fill/></div>
             </div>
             <SquareButton data-testid="postFocusModal-close-button" @click="hideModal"
             class="text-primary bg-btn !rounded-br aspect-square w-10 text-2xl

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -304,14 +304,6 @@ export default defineComponent({
             /**Record of the route the User was using before opening this modal. Navigated back to when
              * the modal is closed. */
             routeEntryPoint:'/',
-            /**Records the current window width of the browser. */
-            windowWidth:0,
-            /**Variable that holds the value of the `timeoutID` used to limit the rate at which `windowWidth` will be updated. */
-            windowResizeTimeout:-1,
-            /**The value used to determine that the app is currently in the "mobile view" layout. A window width lower than this value means `usingMobileLayout` will be `true`. */
-            mobileLayoutWidth:640,
-            /**Value indicating whether or not the app is currently in the "mobile view" layout.*/
-            usingMobileLayout:false,
         }
     },
     methods:{
@@ -614,22 +606,6 @@ export default defineComponent({
             }
             AppState.routeNavigationInfo = null;
         },
-        /**
-         * Method used to update the value of the current browser window width.
-         */
-        windowResized(){
-            this.windowWidth = window.innerWidth;
-            if(this.windowWidth<this.mobileLayoutWidth) this.usingMobileLayout = true
-            else this.usingMobileLayout = false;
-            console.log(`Window Width: ${this.windowWidth} -- Using Mobile Layout: ${this.usingMobileLayout}`);
-        },
-        /**
-         * Method used to restrict the rate the `windowWidth` variable is updated via `onresize` event.
-         */
-        updateWindowResizedWithTimeout(){
-            clearTimeout(this.windowResizeTimeout);
-            this.windowResizeTimeout = setTimeout(this.windowResized,200);
-        }
     },
     computed:{
         /**Checks to see if the current post contains any image media. */
@@ -889,17 +865,12 @@ export default defineComponent({
         this.$el.addEventListener('keydown', this.onKeyboardShorcutEntered);
         (this.$el as HTMLElement).focus();
         document.title = `Loading Post data... | moongate`;
-        //Calculate if app is being displayed with "mobile layout"
-        this.windowWidth = window.innerWidth;
-        if(this.windowWidth<this.mobileLayoutWidth) this.usingMobileLayout = true;
-        window.addEventListener('resize', this.updateWindowResizedWithTimeout)
     },
     beforeUnmount() {
         console.log('Closing PostFocusModal...');
         //Remove keyboard+mouse shortcut listener
         this.$el.removeEventListener('keydown', this.onKeyboardShorcutEntered);
         AppState.handleFocusOnComponentClose();
-        window.removeEventListener('resize', this.updateWindowResizedWithTimeout);
     },
 })
 </script>

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -377,7 +377,7 @@ export default defineComponent({
                 postDetails.isAwaitingFocusData = false;
                 setTimeout(() => {
                     //Restore scroll position
-                    let replyContainer = document.querySelector('[data-testid=postThreadView]');
+                    let replyContainer = document.querySelector(this.replyContainerSelector);
                     if(replyContainer != null){
                         replyContainer.scrollTop = this.threadBranchHistory[this.threadNavIndex].scrollPos;
                     }
@@ -573,7 +573,7 @@ export default defineComponent({
          * @param fromScrollPos Current scroll position of the `PostFocusModal` "reply container".
          */
         manageReplyContainerState(to:RouteLocationNormalizedLoadedGeneric,from:RouteLocationNormalizedLoadedGeneric, fromScrollPos:number){
-            let replyContainer = document.querySelector('[data-testid=postThreadView]');
+            // let replyContainer = document.querySelector(this.replyContainerElement);
             // let scrollPos = replyContainer != null ? replyContainer.scrollTop : 'error finding postThreadView element';
             // console.log(`Scroll position of previous reply container div was: ${scrollPos}px.`);
             //save current "reply area" scroll position before navigating to new view
@@ -793,6 +793,15 @@ export default defineComponent({
             }
             let userId = (typeof postDetails.currentThreadView.post.author.displayName != 'undefined') ? postDetails.currentThreadView.post.author.displayName : postDetails.currentThreadView.post.author.handle;
             return postTextClip.trim() != '' ? `${postTextClip}... by ${userId} | moongate` : `${userId}'s Post | moongate`;
+        },
+        /**
+         * Computed variable that returns the CSS selector value that points to the currently
+         * used container for replies based on if the application is displaying in "mobile"
+         * mode or not.
+         */
+        replyContainerSelector(){
+            if(!AppState.usingMobileLayout) return '[data-testid=postThreadView]';
+            else return '[data-testid=post-focus-modal]';
         }
     },
     watch:{
@@ -818,7 +827,7 @@ export default defineComponent({
             })
         }
         if((from.name == 'postfocusmodal' && to.name == 'postfocusmodal with mediaindex') || (from.name == 'postfocusmodal with mediaindex' && to.name == 'postfocusmodal')){
-            let replyContainer = document.querySelector('[data-testid=postThreadView]');
+            let replyContainer = document.querySelector(vm.replyContainerElement);
             let fromScrollPos = replyContainer != null ? replyContainer.scrollTop : 0;
             next(vm => {
                 vm.manageReplyContainerState(to,from,fromScrollPos);
@@ -830,7 +839,7 @@ export default defineComponent({
         }
     },
     beforeRouteUpdate(to,from){
-        let replyContainer = document.querySelector('[data-testid=postThreadView]');
+        let replyContainer = document.querySelector(this.replyContainerSelector);
         let fromScrollPos = replyContainer != null ? replyContainer.scrollTop : 0;
         this.manageReplyContainerState(to,from,fromScrollPos);
     },

--- a/src/components/Post/PostFocusModal.vue
+++ b/src/components/Post/PostFocusModal.vue
@@ -303,7 +303,15 @@ export default defineComponent({
             lastPostDid:'',
             /**Record of the route the User was using before opening this modal. Navigated back to when
              * the modal is closed. */
-            routeEntryPoint:'/'
+            routeEntryPoint:'/',
+            /**Records the current window width of the browser. */
+            windowWidth:0,
+            /**Variable that holds the value of the `timeoutID` used to limit the rate at which `windowWidth` will be updated. */
+            windowResizeTimeout:-1,
+            /**The value used to determine that the app is currently in the "mobile view" layout. A window width lower than this value means `usingMobileLayout` will be `true`. */
+            mobileLayoutWidth:640,
+            /**Value indicating whether or not the app is currently in the "mobile view" layout.*/
+            usingMobileLayout:false,
         }
     },
     methods:{
@@ -605,6 +613,22 @@ export default defineComponent({
                 this.threadNavIndex++;
             }
             AppState.routeNavigationInfo = null;
+        },
+        /**
+         * Method used to update the value of the current browser window width.
+         */
+        windowResized(){
+            this.windowWidth = window.innerWidth;
+            if(this.windowWidth<this.mobileLayoutWidth) this.usingMobileLayout = true
+            else this.usingMobileLayout = false;
+            console.log(`Window Width: ${this.windowWidth} -- Using Mobile Layout: ${this.usingMobileLayout}`);
+        },
+        /**
+         * Method used to restrict the rate the `windowWidth` variable is updated via `onresize` event.
+         */
+        updateWindowResizedWithTimeout(){
+            clearTimeout(this.windowResizeTimeout);
+            this.windowResizeTimeout = setTimeout(this.windowResized,200);
         }
     },
     computed:{
@@ -864,13 +888,18 @@ export default defineComponent({
         //Add keyboard+mouse shortcut listener
         this.$el.addEventListener('keydown', this.onKeyboardShorcutEntered);
         (this.$el as HTMLElement).focus();
-        document.title = `Loading Post data... | moongate`
+        document.title = `Loading Post data... | moongate`;
+        //Calculate if app is being displayed with "mobile layout"
+        this.windowWidth = window.innerWidth;
+        if(this.windowWidth<this.mobileLayoutWidth) this.usingMobileLayout = true;
+        window.addEventListener('resize', this.updateWindowResizedWithTimeout)
     },
     beforeUnmount() {
         console.log('Closing PostFocusModal...');
         //Remove keyboard+mouse shortcut listener
         this.$el.removeEventListener('keydown', this.onKeyboardShorcutEntered);
         AppState.handleFocusOnComponentClose();
+        window.removeEventListener('resize', this.updateWindowResizedWithTimeout);
     },
 })
 </script>

--- a/src/components/Utilities/SaveMediaModal.vue
+++ b/src/components/Utilities/SaveMediaModal.vue
@@ -39,25 +39,25 @@
                 <SquareButton v-if="isTauri()" @click="saveImage()" title="Save Image [.webp]"
                 :is-disabled="!isFileNameValid || !isFolderSyntaxValid || isDownloading"
                 class="bg-savemodalBtn hover:bg-savemodalBtnHover">
-                    Save Image
+                    Save Image [WEBP]
                 </SquareButton>
                 <!-- <SquareButton v-else :is-disabled="isDownloading" @click="saveImageWebCORSSafe" title="Opens in new tab">Save Image</SquareButton> -->
                 <SquareButton v-else :is-disabled="isDownloading"
                 @click="downloadFileFromBskyCDN((AppState.saveMedia as ViewImage).fullsize ? (AppState.saveMedia as ViewImage).fullsize : (AppState.saveMedia.uri as string), AppState.fileSaveDetails.full)"
                 title="Save Image [.webp]" class="bg-savemodalBtn hover:bg-savemodalBtnHover">
-                    <div>Save Image</div>
+                    <div>Save Image [WEBP]</div>
                     <!-- <i-mingcute:loading-fill v-if="isDownloading" class="spinner"/> -->
                 </SquareButton>
                 <SquareButton v-if="isTauri()" @click="saveImage(true)" title="Save Image [.jpg]"
                 :is-disabled="!isFileNameValid || !isFolderSyntaxValid || isDownloading"
                 class="bg-savemodalBtn hover:bg-savemodalBtnHover">
-                    Save Image as JPG w/ Metadata
+                    Save Image w/ Metadata [JPEG]
                 </SquareButton>
                 <!-- <SquareButton v-else :is-disabled="isDownloading" @click="saveImageWebCORSSafe" title="Opens in new tab">Save Image</SquareButton> -->
                 <SquareButton v-else :is-disabled="isDownloading"
                 @click="downloadFileFromBskyCDN((AppState.saveMedia as ViewImage).fullsize ? (AppState.saveMedia as ViewImage).fullsize : (AppState.saveMedia.uri as string), AppState.fileSaveDetails.full, true)"
                 title="Save Image [.jpg]" class="bg-savemodalBtn hover:bg-savemodalBtnHover">
-                    <div>Save Image as JPG w/ Metadata</div>
+                    <div>Save Image [JPEG]</div>
                     <!-- <i-mingcute:loading-fill v-if="isDownloading" class="spinner"/> -->
                 </SquareButton>
             </div>

--- a/src/state/AppState.vue
+++ b/src/state/AppState.vue
@@ -564,6 +564,48 @@ export const AppState = reactive({
      * Indicates if the event listener that tracks route navigation has been added. Should
      * be added by `PostFocusModal` only once.
      */
-    hasRouteNavigationListenerBeenAdded:false
+    hasRouteNavigationListenerBeenAdded:false,
+    /**Records the current window width of the browser. */
+    windowWidth:0,
+    /**Variable that holds the value of the `timeoutID` used to limit the rate at which `windowWidth` will be updated. */
+    windowResizeTimeout:-1,
+    /**The value used to determine that the app is currently in the "mobile view" layout. A window width lower than this value means `usingMobileLayout` will be `true`. */
+    mobileLayoutWidth:640,
+    /**Value indicating whether or not the app is currently in the "mobile view" layout.*/
+    usingMobileLayout:false,
+    /**
+     * Method used to update the value of the current browser window width.
+     */
+    windowResized(){
+        AppState.windowWidth = window.innerWidth;
+        if(AppState.windowWidth<AppState.mobileLayoutWidth) AppState.usingMobileLayout = true
+        else AppState.usingMobileLayout = false;
+        console.log(`Window Width: ${AppState.windowWidth} -- Using Mobile Layout: ${AppState.usingMobileLayout}`);
+    },
+    /**
+     * Method used to restrict the rate the `windowWidth` variable is updated via `onresize` event.
+     * @constructor
+     */
+    updateWindowResizedWithTimeout(){
+        clearTimeout(AppState.windowResizeTimeout);
+        AppState.windowResizeTimeout = setTimeout(AppState.windowResized,200);
+    },
+    /**
+     * Method used to attach {@link AppState.updateWindowResizedWithTimeout() updateWindowResizedWithTimeout()} to the browser/application window
+     * resize event.
+     */
+    setupWindowResizeListener(){
+        //Calculate if app is being displayed with "mobile layout"
+        AppState.windowWidth = window.innerWidth;
+        if(AppState.windowWidth<AppState.mobileLayoutWidth) AppState.usingMobileLayout = true;
+        window.addEventListener('resize', AppState.updateWindowResizedWithTimeout)
+    },
+    /**
+     * Method used to remove {@link AppState.updateWindowResizedWithTimeout() updateWindowResizedWithTimeout()} from the browser/application window
+     * resize event.
+     */
+    removeWindowResizeListener(){
+        window.removeEventListener('resize', AppState.updateWindowResizedWithTimeout);
+    }
 })
 </script>

--- a/tests/PostFocusModal.spec.ts
+++ b/tests/PostFocusModal.spec.ts
@@ -47,7 +47,7 @@ test.beforeAll(async ({browser}) => {
     })
 })
 
-test('Ensure scroll position for reply container is remembered when navigating through reply tree', async({browser},testInfo) => {
+test('Ensure scroll position for reply container is remembered when navigating through reply tree - Desktop layout', async({browser},testInfo) => {
     //mock feed results
     let returnedFeeds = [[post2,post1],[post1,post2]]; //allows "different" Feeds to be returned when querying `getAuthorFeed`
     let feedIndex = 0; //tracks how many `getAuthorFeed` requests have been made, used to return content from array above
@@ -200,5 +200,161 @@ test('Ensure scroll position for reply container is remembered when navigating t
     await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
     //Check that the reply container scroll position is 98px
     returnScrollPos = await instance1.getByTestId('postThreadView').evaluate((e) => {return e.scrollTop});
+    expect(returnScrollPos).toEqual(98);
+})
+
+test('Ensure scroll position for reply container is remembered when navigating through reply tree - Mobile layout', async({browser},testInfo) => {
+    //mock feed results
+    let returnedFeeds = [[post2,post1],[post1,post2]]; //allows "different" Feeds to be returned when querying `getAuthorFeed`
+    let feedIndex = 0; //tracks how many `getAuthorFeed` requests have been made, used to return content from array above
+    //set up tabs
+    const context = await browser.newContext({viewport:{height:700,width:600}});
+    const instance1 = await context.newPage();
+    //set API mocks
+    await context.route(/app.bsky.actor.searchActors/, route => {
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify(actorSearchResults)
+        });
+    });
+    await context.route(/app.bsky.actor.getProfile/, route => {
+            route.fulfill({
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+                body:JSON.stringify(profile1)
+            });
+        });
+    await context.route(/app.bsky.feed.getAuthorFeed/, route => {
+        let f:FeedViewPost[] = [];
+        if(feedIndex<returnedFeeds.length) f = returnedFeeds[feedIndex];
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body:JSON.stringify({feed:f})
+        });
+        feedIndex++;
+    });
+    await context.route(/app.bsky.feed.getPostThread/, route => {
+        const postUrl = new URL(route.request().url());
+        const postUri = postUrl.searchParams.get('uri');
+        let postId = '';
+        if(postUrl != null && postUri != null){
+            let urlSections = postUri.split('/');
+            if(urlSections.length>1) postId = urlSections[urlSections.length-1];
+        }
+        let result:$Typed<ThreadViewPost>|$Typed<NotFoundPost>|$Typed<BlockedPost>|{$type: string;}|boolean = {$type:"app.bsky.feed.defs#notFoundPost",uri:'at://not.found.post/sorry',notFound:true} as $Typed<NotFoundPost>;
+        let searchResult = FindThreadViewPostReply(threadViewPost1.thread,postId);
+        if(searchResult !== false) result = searchResult;
+        route.fulfill({
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            // body:JSON.stringify(threadViewPost1)
+            body:JSON.stringify({thread:result} as AppBskyFeedGetPostThread.OutputSchema)
+        });
+    });
+    //go to app home page
+    await instance1.goto(`/`,{waitUntil:'networkidle'});
+
+    //browse as guest
+    await instance1.getByTestId('add-feed-button').click();
+    await instance1.getByTestId('browse-as-guest-button').click();
+    //add new feed
+    await instance1.getByTestId('add-feed-button').click();
+    await instance1.getByTestId('feedEditModal-user-feed-button').click();
+    await instance1.getByTestId('feedEditModal-next-page-button').click();
+    await instance1.getByTestId('inlainput-input').fill('username');
+    await instance1.getByTestId('inlainput-input').press('Enter');
+    await expect(instance1.getByTestId('user-search-bar-result').nth(0)).toBeVisible();
+    await instance1.getByTestId('user-search-bar-result').nth(0).click();
+    await expect(instance1.getByText('submit')).toBeVisible();
+    await instance1.getByTestId('feedEditModal-create-button').click();
+    await expect(instance1.getByTestId('feed-edit-modal')).toBeHidden();
+
+    //CHECK THAT THREAD BRANCH HISTORY + SCROLL POSITION RESTORE WORKS AS EXPECTED
+    //open Post in PostFocusModal
+    await instance1.getByTestId('focusFeedPost-timestamp-button').nth(0).click();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Scroll down reply container 100px
+    await instance1.getByTestId('post-focus-modal').evaluate(e => e.scrollTop += 100);
+    const scrollPosBefore = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(scrollPosBefore).toEqual(100);
+    //Click on 2nd reply timestamp to view (uses dispatch so that playwright does not scroll element into position)
+    await instance1.getByTestId('post-focus-modal').getByTestId('focusFeedPost-timestamp-button').nth(1).dispatchEvent('click');
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Focused post should have changed, confirm
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded').getByTestId('postFocusModal-text')).toContainText('reply 2 on the parent');
+    //scroll down to see last reply
+    await instance1.getByTestId('post-focus-modal').evaluate(e => e.scrollTop += 1000);
+    const replyScrollPosBefore = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    //navigate back to parent post
+    await instance1.goBack();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    const scrollPosAfter = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(scrollPosAfter).toEqual(100);
+    //go forward to reply again
+    await instance1.goForward();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Check that reply scroll was restored correctly
+    const replyScrollPosAfter = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(replyScrollPosAfter).toEqual(replyScrollPosBefore);
+
+    ///CHECK THREAD BRANCH HISTORY DOES NOT BREAK WHEN USING HISTORY API (back/forwards)
+    //Close `PostFocusModal`
+    await instance1.getByTestId('postFocusModal-close-button-mobile').click();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeHidden();
+    //Navigate back to reply in `PostFocusModal`
+    await instance1.goBack();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Check that the reply container scroll position is 0px
+    let returnScrollPos = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(returnScrollPos).toEqual(0);
+    //Scroll down 111px
+    await instance1.getByTestId('post-focus-modal').evaluate(e => e.scrollTop += 111);
+    returnScrollPos = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(returnScrollPos).toEqual(111);
+    //Navigate back again to thread root
+    await instance1.goBack();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Check that the thread root reply container scroll position is 0px
+    returnScrollPos = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(returnScrollPos).toEqual(0);
+    //Scroll down 123px
+    await instance1.getByTestId('post-focus-modal').evaluate(e => e.scrollTop += 123);
+    returnScrollPos = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(returnScrollPos).toEqual(123);
+    //Go forward through browser history to reply
+    await instance1.goForward();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Check that the reply container scroll position is 0px
+    returnScrollPos = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(returnScrollPos).toEqual(0);
+
+    //CHECK THAT THREAD BRANCH HISTORY CAN BE CREATED CORRECTLY AFTER NAVIGATING WITH HISTORY API
+    //Navigate back again to thread root
+    await instance1.goBack();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Scroll down 72px
+    await instance1.getByTestId('post-focus-modal').evaluate(e => e.scrollTop += 72);
+    returnScrollPos = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(returnScrollPos).toEqual(72);
+    //Click on 2nd reply timestamp to view (uses dispatch so that playwright does not scroll element into position)
+    await instance1.getByTestId('post-focus-modal').getByTestId('focusFeedPost-timestamp-button').nth(1).dispatchEvent('click');
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Scroll down 98px
+    await instance1.getByTestId('post-focus-modal').evaluate(e => e.scrollTop += 98);
+    returnScrollPos = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(returnScrollPos).toEqual(98);
+    //Navigate back again to thread root
+    await instance1.goBack();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Check that the reply container scroll position is 72px
+    returnScrollPos = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
+    expect(returnScrollPos).toEqual(72);
+    //Navigate forward to 2nd reply again
+    await instance1.goForward();
+    await expect(instance1.getByTestId('postFocusModal-focus-post-loaded')).toBeVisible();
+    //Check that the reply container scroll position is 98px
+    returnScrollPos = await instance1.getByTestId('post-focus-modal').evaluate((e) => {return e.scrollTop});
     expect(returnScrollPos).toEqual(98);
 })


### PR DESCRIPTION
- Updated application so the "reply container" scroll position in `PostFocusModal` is correctly saved and restored when navigating a Post's thread while the application is displayed using the "mobile" layout.
- Created new Playwright test to ensure expected "save/restore" behavior of "reply container" scroll position when using the "mobile" layout.
- Updated the buttons on `SaveMediaModal` used to save images so that the file format that the images will be saved as are better communicated.