### PR TITLE
Hotfix #295 - Fixes issue copying Post link on mobile

### DIFF
--- a/src/components/Post/PostInteractionIcons.vue
+++ b/src/components/Post/PostInteractionIcons.vue
@@ -67,7 +67,7 @@ import { CreateBskyWeblink, getCompactNumberValue } from '../../helpers/converte
 import { OptionsMenuState } from '../../state/OptionsMenuState.vue';
 import { IOptionMenuItem, ItemType } from '../Utilities/OptionsMenu.vue';
 import { PostView, ThreadViewPost } from '@atproto/api/dist/client/types/app/bsky/feed/defs';
-import { AppState, toast } from '../../state/AppState.vue';
+import { AppState, CopyTextToClipboard, toast } from '../../state/AppState.vue';
 import { PostActions } from '../../enums/PostEnums';
 import { GetBrowsingAgent } from '../../lib/api.vue';
 import { BookmarkPost, DeletePost, RemoveBookmark } from '../../lib/api/Post.vue';
@@ -77,8 +77,10 @@ import { toggleBlock, toggleMute } from '../../lib/api/User.vue';
 
 function CopyPostLink(postUri:string, handle:string=""){
     let link = CreateBskyWeblink(postUri, handle);
-    if(link) navigator.clipboard.writeText(link);
-    //Need to add toast or something to alert the User that link has been copied
+    if(typeof link != 'undefined')
+        CopyTextToClipboard(link, 'link');
+    else
+        toast.add({summary:'Error creating Link',severity:'error', group:'bc', life:1000});
 }
 
 /**

--- a/src/components/Settings/AboutAppModal.vue
+++ b/src/components/Settings/AboutAppModal.vue
@@ -39,9 +39,17 @@
             <div class="flex flex-col overflow-y-auto pt-2">
                 <div class="px-4 text-xl font-semibold">Changelog:</div>
                 <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
+                    <div class="font-semibold">March 27th 2026</div>
+                    <ul class="list-disc list-inside h-full py-1 text-sm">
+                        <li>Updated display when viewing a Post Thread so that the quoted post in a Quote Retweet (QRT) is displayed underneath the main post content.</li>
+                        <li>Post Thread view now has a "control bar" at the top of the component to provide post context as well as useful functions ('scroll to top', 'view post image' etc.).</li>
+                        <li>See details here: (<ExternalLink link-url="https://github.com/sondaismith/moongate/pull/294">#294</ExternalLink>)</li>
+                    </ul>
+                </div>
+                <div class="flex flex-col gap-1 h-full px-4 divide-outline divide-y">
                     <div class="font-semibold">March 17th 2026</div>
                     <ul class="list-disc list-inside h-full py-1 text-sm">
-                        <li>Fixed issue where image containers could not correctly idenntify the file extension of the new WEBP images the Bluesky CDN delivers by default.</li>
+                        <li>Fixed issue where image containers could not correctly identify the file extension of the new WEBP images the Bluesky CDN delivers by default.</li>
                         <li>Added ability to choose whether to save images as a WEBP or JPEG.</li>
                         <li>See details here: (<ExternalLink link-url="https://github.com/sondaismith/moongate/pull/288">#288</ExternalLink>)</li>
                     </ul>

--- a/src/components/Utilities/InLaInput.vue
+++ b/src/components/Utilities/InLaInput.vue
@@ -18,7 +18,7 @@
 <script lang="ts">
 import { isTauri } from '@tauri-apps/api/core';
 import { defineComponent } from 'vue'
-import { toast } from '../../state/AppState.vue';
+import { CopyTextToClipboard, toast } from '../../state/AppState.vue';
 
 interface Emits{
     /**Triggered when the passed `modelValue` is updated by the control. */
@@ -96,33 +96,7 @@ export default defineComponent({
         },
         /**Allows the User to quickly copy the text contained in this control. */
         copyText(){
-            if(navigator.clipboard){//Modern method - requires app to serve page(s) over HTTPS
-                try{
-                    navigator.clipboard.writeText(this.modelValue ? this.modelValue : '');
-                    toast.add({summary:'Text Copied',severity:'success', group:'bc', life:1000});
-                }
-                catch(err){
-                    console.error('Unable to copy to clipboard', err);
-                    toast.add({summary:'Error copying text',severity:'error', group:'bc', life:1000});
-                }
-            }
-            else{
-                //Unsecured text copy
-                const textArea = document.createElement("textarea");
-                textArea.value = this.modelValue ? this.modelValue : '';
-                document.body.appendChild(textArea);
-                textArea.focus();
-                textArea.select();
-                try{
-                    document.execCommand('copy');
-                    toast.add({summary:'Text Copied',severity:'success', group:'bc', life:1000});
-                }
-                catch(err){
-                    console.error('Unable to copy to clipboard', err);
-                    toast.add({summary:'Error copying text',severity:'error', group:'bc', life:1000});
-                }
-                document.body.removeChild(textArea);
-            }
+            CopyTextToClipboard(typeof this.modelValue != 'undefined' ? this.modelValue : '');
         }
     },
     setup () {


### PR DESCRIPTION
- Fixed issue where copying a Post link with `PostInteractionIcons` would not work on mobile. Modified method so it uses `AppState.CopyTextToClipboard()`.
- Updated in-app changelog to list details of previous `PostFocusModal` update.